### PR TITLE
feat: enhanced Italgiure search with facets and auto-refinement

### DIFF
--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.1",
   "name": "legal-it",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "display_name": "Legal IT — Diritto Italiano",
   "description": "164 tool di calcolo legale italiano, normativa (Normattiva/EUR-Lex), giurisprudenza (Cassazione/Italgiure), delibere CONSOB e compliance GDPR.",
   "long_description": "Server MCP completo per il diritto italiano. Include: calcoli rivalutazione/interessi, scadenze processuali, parcelle avvocati, risarcimento danni, decreto ingiuntivo, IRPEF/TFR, successioni, codice fiscale, privacy GDPR. Consultazione normativa da Normattiva e EUR-Lex, giurisprudenza di Cassazione da Italgiure, annotazioni da Brocardi, delibere CONSOB.",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legal-it",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Plugin legale italiano completo: 164 tool di calcolo, normativa (Normattiva/EUR-Lex), giurisprudenza (Cassazione/Italgiure), CONSOB, compliance GDPR. 18 skill tool-aware, 8 slash command, 3 agenti specializzati.",
   "author": {
     "name": "capazme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-legal-it"
-version = "1.1.1"
+version = "1.1.2"
 description = "MCP server with 164 Italian legal tools: calculations, legislation, case law, CONSOB, GDPR"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/lib/italgiure/__init__.py
+++ b/src/lib/italgiure/__init__.py
@@ -1,9 +1,12 @@
 from .client import (
     TIPO_PROV,
+    SolrSession,
+    build_explore_params,
     build_lookup_params,
     build_norma_variants,
     build_search_params,
     format_estremi,
+    format_facets,
     format_full_text,
     format_summary,
     get_kind_filter,
@@ -12,10 +15,13 @@ from .client import (
 
 __all__ = [
     "TIPO_PROV",
+    "SolrSession",
+    "build_explore_params",
     "build_lookup_params",
     "build_norma_variants",
     "build_search_params",
     "format_estremi",
+    "format_facets",
     "format_full_text",
     "format_summary",
     "get_kind_filter",

--- a/src/lib/italgiure/client.py
+++ b/src/lib/italgiure/client.py
@@ -6,6 +6,8 @@ SSL: verify=False (invalid cert on www.italgiure.giustizia.it).
 Collections: snciv (civile), snpen (penale) — filtered via kind field in query.
 """
 
+from __future__ import annotations
+
 import re
 import urllib.parse
 
@@ -36,6 +38,8 @@ TIPO_PROV = {"sentenza": "S", "ordinanza": "O", "decreto": "D"}
 _TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 _MAX_OCR_LENGTH = 30000
 
+_FACET_FIELDS = ["materia", "szdec", "anno", "tipoprov"]
+
 _SEZIONI = {
     "1": "I",
     "2": "II",
@@ -49,6 +53,8 @@ _SEZIONI = {
     "SU": "SS.UU.",
     "U": "sez. un.",
 }
+
+_TIPO_LABELS = {"S": "sentenza", "O": "ordinanza", "D": "decreto"}
 
 _RAMO = {"snciv": "civ.", "snpen": "pen."}
 
@@ -72,13 +78,42 @@ def _first(val) -> str:
     return str(val) if val is not None else ""
 
 
-async def solr_query(params: dict) -> dict:
+class SolrSession:
+    """Reusable Solr session — fetches homepage cookie once, reuses for N queries."""
+
+    def __init__(self) -> None:
+        self._client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> SolrSession:
+        self._client = httpx.AsyncClient(verify=False, timeout=_TIMEOUT, headers=_HEADERS)
+        await self._client.get(_HOMEPAGE)
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def query(self, params: dict) -> dict:
+        if self._client is None:
+            raise RuntimeError("SolrSession not entered — use `async with`")
+        body = urllib.parse.urlencode({**params, "wt": "json", "indent": "off"}, doseq=True)
+        resp = await self._client.post(_SOLR_URL, content=body)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def solr_query(params: dict, session: SolrSession | None = None) -> dict:
     """Execute Solr query against Italgiure unified endpoint.
 
     Uses POST to /sn-collection/select?app.query with form-encoded body.
     Fetches homepage first to obtain session cookie. verify=False for invalid SSL.
     Handles list-valued params (e.g. multiple fq) via urlencode(doseq=True).
+
+    If *session* is provided, reuses its client (no extra homepage fetch).
     """
+    if session is not None:
+        return await session.query(params)
     async with httpx.AsyncClient(verify=False, timeout=_TIMEOUT, headers=_HEADERS) as client:
         await client.get(_HOMEPAGE)
         body = urllib.parse.urlencode({**params, "wt": "json", "indent": "off"}, doseq=True)
@@ -100,27 +135,43 @@ def build_search_params(
     rows: int = 5,
     start: int = 0,
     highlight: bool = True,
+    campo: str = "tutto",
+    include_facets: bool = False,
+    mm: str | None = None,
 ) -> dict:
     """Build eDisMax params for full-text search.
 
     ordinamento: "rilevanza" (score desc) or "data" (pd desc).
+    campo: "tutto" (ocrdis+ocr, default) or "dispositivo" (solo ocrdis).
+    include_facets: if True, adds facet params for materia/szdec/anno/tipoprov.
+    mm: override minimum-should-match (default "2<75% 5<60%").
     """
     kinds = get_kind_filter(archivio)
     kind_clause = " OR ".join(f'kind:"{k}"' for k in kinds)
     sort = "score desc" if ordinamento == "rilevanza" else "pd desc"
+    if campo == "dispositivo":
+        qf = "ocrdis^1"
+        pf = "ocrdis^3"
+        pf2 = "ocrdis^2"
+        pf3 = "ocrdis^1"
+    else:
+        qf = "ocrdis^5 ocr^1"
+        pf = "ocrdis^10 ocr^3"
+        pf2 = "ocrdis^6 ocr^2"
+        pf3 = "ocrdis^4 ocr^1"
     params: dict = {
         "defType": "edismax",
         "q": query,
-        "qf": "ocrdis^5 ocr^1",
-        "pf": "ocrdis^10 ocr^3",
-        "pf2": "ocrdis^6 ocr^2",
-        "pf3": "ocrdis^4 ocr^1",
-        "mm": "2<75% 5<60%",
+        "qf": qf,
+        "pf": pf,
+        "pf2": pf2,
+        "pf3": pf3,
+        "mm": mm or "2<75% 5<60%",
         "fq": [f"({kind_clause})"],
         "sort": sort,
         "rows": rows,
         "start": start,
-        "fl": "id,numdec,anno,datdep,szdec,materia,tipoprov,ocrdis,kind",
+        "fl": "id,numdec,anno,datdep,szdec,materia,tipoprov,ocrdis,kind,score",
     }
     if materia:
         params["fq"].append(f"materia:{materia}")
@@ -136,6 +187,11 @@ def build_search_params(
         params["fq"].append(f"anno:[{anno_da} TO *]")
     elif anno_a:
         params["fq"].append(f"anno:[* TO {anno_a}]")
+    if include_facets:
+        params["facet"] = "true"
+        params["facet.field"] = _FACET_FIELDS
+        params["facet.limit"] = 10
+        params["facet.mincount"] = 1
     if highlight:
         params.update({
             "hl": "true",
@@ -144,6 +200,68 @@ def build_search_params(
             "hl.snippets": "2",
         })
     return params
+
+
+def build_explore_params(
+    query: str,
+    archivio: str = "tutti",
+    campo: str = "tutto",
+) -> dict:
+    """Build params for facet-only exploration (rows=0, no documents).
+
+    Returns distribution by materia, sezione, anno, tipo provvedimento.
+    """
+    kinds = get_kind_filter(archivio)
+    kind_clause = " OR ".join(f'kind:"{k}"' for k in kinds)
+    if campo == "dispositivo":
+        qf = "ocrdis^1"
+    else:
+        qf = "ocrdis^5 ocr^1"
+    return {
+        "defType": "edismax",
+        "q": query,
+        "qf": qf,
+        "mm": "2<75% 5<60%",
+        "fq": [f"({kind_clause})"],
+        "rows": 0,
+        "fl": "id",
+        "facet": "true",
+        "facet.field": _FACET_FIELDS,
+        "facet.limit": 15,
+        "facet.mincount": 1,
+    }
+
+
+def format_facets(facet_counts: dict, num_found: int) -> str:
+    """Format Solr facet_counts into readable markdown.
+
+    Maps szdec codes to section names, tipoprov codes to type names.
+    Returns empty string if no facet data.
+    """
+    facet_fields = facet_counts.get("facet_fields", {})
+    if not facet_fields:
+        return ""
+    lines = [f"**Distribuzione risultati** ({num_found} totali):"]
+    field_labels = {
+        "materia": "Materia",
+        "szdec": "Sezione",
+        "anno": "Anno",
+        "tipoprov": "Tipo",
+    }
+    for field_name, label in field_labels.items():
+        raw = facet_fields.get(field_name, [])
+        pairs = list(zip(raw[0::2], raw[1::2]))
+        if not pairs:
+            continue
+        formatted = []
+        for name, count in pairs:
+            if field_name == "szdec":
+                name = _SEZIONI.get(str(name), str(name))
+            elif field_name == "tipoprov":
+                name = _TIPO_LABELS.get(str(name), str(name))
+            formatted.append(f"{name} ({count})")
+        lines.append(f"- **{label}**: {', '.join(formatted)}")
+    return "\n".join(lines)
 
 
 def build_lookup_params(

--- a/src/tools/italgiure.py
+++ b/src/tools/italgiure.py
@@ -7,14 +7,45 @@ Non fare web search per sentenze già identificate — il testo ufficiale è su 
 from src.server import mcp
 from src.lib.italgiure.client import (
     TIPO_PROV,
+    SolrSession,
+    build_explore_params,
     build_lookup_params,
     build_norma_variants,
     build_search_params,
+    format_facets,
     format_full_text,
     format_summary,
     get_kind_filter,
     solr_query,
 )
+
+_SCORE_RATIO_THRESHOLD = 0.2
+_REFINEMENT_THRESHOLD = 50
+
+_REFINEMENT_STEPS = [
+    {"mm": "100%", "label": "tutti i termini richiesti"},
+    {"campo": "dispositivo", "label": "solo nel dispositivo"},
+    {"tipo_provvedimento": "sentenza", "label": "solo sentenze"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Score filtering
+# ---------------------------------------------------------------------------
+
+def _filter_by_score(docs: list[dict]) -> tuple[list[dict], int]:
+    """Keep only docs with score > 20% of the maximum. Passthrough if score absent."""
+    if not docs:
+        return docs, 0
+    scores = [d.get("score") for d in docs]
+    if scores[0] is None:
+        return docs, 0
+    max_score = max(float(s) for s in scores if s is not None)
+    if max_score == 0:
+        return docs, 0
+    threshold = max_score * _SCORE_RATIO_THRESHOLD
+    filtered = [d for d in docs if float(d.get("score", 0)) >= threshold]
+    return filtered, len(docs) - len(filtered)
 
 
 # ---------------------------------------------------------------------------
@@ -50,7 +81,13 @@ async def _cerca_giurisprudenza_impl(
     ordinamento: str = "rilevanza",
     max_risultati: int = 5,
     pagina: int = 0,
+    campo: str = "tutto",
+    modalita: str = "cerca",
 ) -> str:
+    # --- Explore mode: facets only, no documents ---
+    if modalita == "esplora":
+        return await _esplora_impl(query, archivio=archivio, campo=campo)
+
     max_risultati = min(max_risultati, 50)
     params = build_search_params(
         query,
@@ -64,25 +101,168 @@ async def _cerca_giurisprudenza_impl(
         ordinamento=ordinamento,
         rows=max_risultati,
         start=pagina * max_risultati,
+        campo=campo,
+        include_facets=True,
     )
     try:
         data = await solr_query(params)
     except Exception as exc:
         return f"Errore nella ricerca: {exc}"
-    docs = data.get("response", {}).get("docs", [])
+
     num_found = data.get("response", {}).get("numFound", 0)
+    facet_counts = data.get("facet_counts", {})
+
+    # --- Auto-refinement when too many results ---
+    if (
+        num_found > _REFINEMENT_THRESHOLD
+        and ordinamento == "rilevanza"
+        and pagina == 0
+        and not any([materia, sezione, tipo_provvedimento, solo_sezioni_unite])
+    ):
+        refined = await _auto_refine(
+            query, archivio, anno_da, anno_a, max_risultati,
+            num_found, facet_counts, data,
+        )
+        if refined is not None:
+            return refined
+
+    return _format_search_results(
+        data, query, ordinamento, pagina, max_risultati, num_found, facet_counts,
+    )
+
+
+async def _esplora_impl(
+    query: str,
+    archivio: str = "tutti",
+    campo: str = "tutto",
+) -> str:
+    """Facet-only exploration: returns distribution without documents."""
+    params = build_explore_params(query, archivio=archivio, campo=campo)
+    try:
+        data = await solr_query(params)
+    except Exception as exc:
+        return f"Errore nell'esplorazione: {exc}"
+    num_found = data.get("response", {}).get("numFound", 0)
+    if num_found == 0:
+        return "Nessuna decisione trovata per la ricerca indicata."
+    facet_counts = data.get("facet_counts", {})
+    lines = [f"**Esplorazione**: _{query}_ — {num_found} decisioni trovate\n"]
+    facets_text = format_facets(facet_counts, num_found)
+    if facets_text:
+        lines.append(facets_text)
+    lines.append("")
+    lines.append("> **Suggerimento**: usa `modalita=\"cerca\"` con filtri specifici (materia, sezione, anno, tipo_provvedimento) per ottenere risultati mirati.")
+    return "\n".join(lines)
+
+
+async def _auto_refine(
+    query: str,
+    archivio: str,
+    anno_da: int,
+    anno_a: int,
+    max_risultati: int,
+    original_num_found: int,
+    original_facets: dict,
+    original_data: dict,
+) -> str | None:
+    """Try progressive refinement steps to reduce results below threshold.
+
+    Returns formatted output if refinement succeeded, None to fall back to original.
+    """
+    best_data = None
+    best_count = original_num_found
+    best_label = ""
+
+    try:
+        async with SolrSession() as session:
+            for step in _REFINEMENT_STEPS:
+                step_params = build_search_params(
+                    query,
+                    archivio=archivio,
+                    anno_da=anno_da or None,
+                    anno_a=anno_a or None,
+                    rows=max_risultati,
+                    start=0,
+                    campo=step.get("campo", "tutto"),
+                    mm=step.get("mm"),
+                    tipo_provvedimento=step.get("tipo_provvedimento"),
+                    include_facets=True,
+                )
+                step_data = await solr_query(step_params, session=session)
+                step_count = step_data.get("response", {}).get("numFound", 0)
+                if 0 < step_count <= _REFINEMENT_THRESHOLD:
+                    return _format_search_results(
+                        step_data, query, "rilevanza", 0, max_risultati,
+                        step_count,
+                        step_data.get("facet_counts", {}),
+                        refinement_note=f"Raffinamento automatico: {step['label']} ({original_num_found} → {step_count})",
+                    )
+                if 0 < step_count < best_count:
+                    best_data = step_data
+                    best_count = step_count
+                    best_label = step["label"]
+    except Exception:
+        return None
+
+    if best_data is not None and best_count < original_num_found:
+        return _format_search_results(
+            best_data, query, "rilevanza", 0, max_risultati,
+            best_count,
+            best_data.get("facet_counts", {}),
+            refinement_note=f"Raffinamento automatico: {best_label} ({original_num_found} → {best_count})",
+        )
+    return None
+
+
+def _format_search_results(
+    data: dict,
+    query: str,
+    ordinamento: str,
+    pagina: int,
+    max_risultati: int,
+    num_found: int,
+    facet_counts: dict,
+    refinement_note: str = "",
+) -> str:
+    """Format Solr search results into markdown output."""
+    docs = data.get("response", {}).get("docs", [])
     highlighting = data.get("highlighting", {})
+
     if not docs:
         return "Nessuna decisione trovata per la ricerca indicata."
+
+    # Score filtering
+    docs, dropped = _filter_by_score(docs)
+    if not docs:
+        return "Nessuna decisione trovata per la ricerca indicata."
+
     start_idx = pagina * max_risultati + 1
     end_idx = start_idx + len(docs) - 1
     ord_label = "per rilevanza" if ordinamento == "rilevanza" else "per data"
-    lines = [f"**Trovate {num_found} decisioni** per: _{query}_ (mostro {start_idx}-{end_idx}, {ord_label})\n"]
+
+    if dropped > 0:
+        lines = [f"**Trovate {num_found} decisioni** ({len(docs)} ad alta rilevanza) per: _{query}_ (mostro {start_idx}-{end_idx}, {ord_label})\n"]
+    else:
+        lines = [f"**Trovate {num_found} decisioni** per: _{query}_ (mostro {start_idx}-{end_idx}, {ord_label})\n"]
+
+    if refinement_note:
+        lines.append(f"*{refinement_note}*\n")
+
     for doc in docs:
         doc_id = doc.get("id", "")
         hl = highlighting.get(doc_id)
         lines.append(format_summary(doc, hl))
         lines.append("")
+
+    # Append facets if many results
+    if num_found > _REFINEMENT_THRESHOLD and facet_counts:
+        facets_text = format_facets(facet_counts, num_found)
+        if facets_text:
+            lines.append("---")
+            lines.append(facets_text)
+            lines.append("")
+            lines.append('> **Suggerimento**: restringi con filtri specifici (materia, sezione, anno, tipo_provvedimento)')
+
     return "\n".join(lines)
 
 
@@ -224,17 +404,29 @@ async def cerca_giurisprudenza(
     ordinamento: str = "rilevanza",
     max_risultati: int = 5,
     pagina: int = 0,
+    campo: str = "tutto",
+    modalita: str = "cerca",
 ) -> str:
-    """Ricerca full-text nelle sentenze della Cassazione su Italgiure (fonte ufficiale).
+    """Ricerca full-text nelle sentenze della Cassazione su Italgiure (fonte ufficiale, archivio 2020+).
 
-    Usare per trovare decisioni su un tema quando non si conosce il numero specifico.
-    Una volta trovato il numero, usare leggi_sentenza() per il testo completo.
-    Dopo questo tool: leggi_sentenza() per leggere il testo integrale delle decisioni trovate.
-    Restituisce: lista di decisioni con numero, data, sezione, dispositivo e snippet matching.
-    L'output mostra il totale trovato e il range visualizzato. Usare pagina>0 per navigare.
+    **Strategia consigliata**:
+    1. Prima esplora: `modalita="esplora"` per vedere distribuzione risultati (materia, sezione, anno, tipo)
+    2. Poi cerca con filtri: usa i filtri suggeriti per restringere a <50 risultati
+    3. Leggi i testi: `leggi_sentenza()` per il testo completo delle decisioni trovate
+
+    **Sintassi query Solr** (campo `query`):
+    - `"frase esatta"` — virgolette per match esatto
+    - `AND` / `OR` — operatori booleani (default: OR tra i termini)
+    - `-termine` — esclude termine
+    - `"frase esatta"~3` — prossimità (termini entro 3 parole)
+    - `termin*` — wildcard (prefisso)
+
+    Con query generiche (es. "responsabilità medica") il sistema tenta un raffinamento automatico
+    per ridurre i risultati. Se i risultati sono >50, mostra anche la distribuzione per facet.
+    Con `modalita="esplora"` non restituisce documenti, solo la distribuzione.
 
     Args:
-        query: Testo da cercare nel corpo delle decisioni
+        query: Testo da cercare nel corpo delle decisioni (supporta sintassi Solr eDisMax)
         archivio: "civile", "penale", o "tutti" (default)
         materia: Filtro per materia (es. "contratti", "responsabilita' civile")
         sezione: Filtro sezione (1-6, L=lavoro, T=tributaria, SU=sezioni unite)
@@ -245,12 +437,14 @@ async def cerca_giurisprudenza(
         ordinamento: "rilevanza" (score desc, default) o "data" (più recenti prima)
         max_risultati: Numero massimo di risultati per pagina (default 5, max 50)
         pagina: Pagina dei risultati, 0-indexed (default 0 = prima pagina)
+        campo: "tutto" (testo+dispositivo, default) o "dispositivo" (cerca solo nel dispositivo — più preciso, meno recall)
+        modalita: "cerca" (default — restituisce documenti) o "esplora" (solo distribuzione facet, nessun documento)
     """
     return await _cerca_giurisprudenza_impl(
         query, archivio=archivio, materia=materia, sezione=sezione,
         anno_da=anno_da, anno_a=anno_a, tipo_provvedimento=tipo_provvedimento,
         solo_sezioni_unite=solo_sezioni_unite, ordinamento=ordinamento,
-        max_risultati=max_risultati, pagina=pagina,
+        max_risultati=max_risultati, pagina=pagina, campo=campo, modalita=modalita,
     )
 
 

--- a/tests/unit/test_italgiure.py
+++ b/tests/unit/test_italgiure.py
@@ -7,10 +7,13 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.lib.italgiure.client import (
+    SolrSession,
+    build_explore_params,
     build_lookup_params,
     build_norma_variants,
     build_search_params,
     format_estremi,
+    format_facets,
     format_full_text,
     format_summary,
     get_kind_filter,
@@ -21,6 +24,7 @@ from src.lib.italgiure.client import (
 # Import _impl functions at module level to avoid metaclass conflict when patching httpx
 from src.tools.italgiure import (
     _cerca_giurisprudenza_impl,
+    _filter_by_score,
     _giurisprudenza_su_norma_impl,
     _leggi_sentenza_impl,
     _ultime_pronunce_impl,
@@ -1066,3 +1070,664 @@ class TestUltimePronunceImpl:
         body = captured.get("body", "")
         assert "contratti" in body
         assert "rows=3" in body
+
+
+# ---------------------------------------------------------------------------
+# SolrSession
+# ---------------------------------------------------------------------------
+
+class TestSolrSession:
+    @pytest.mark.asyncio
+    async def test_session_reuses_client(self):
+        """Session should call GET homepage once and allow multiple queries."""
+        get_count = 0
+        post_count = 0
+
+        async def mock_get(url, **kwargs):
+            nonlocal get_count
+            get_count += 1
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        async def mock_post(url, content=None, **kwargs):
+            nonlocal post_count
+            post_count += 1
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            resp.json = MagicMock(return_value=_make_solr_response([]))
+            return resp
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.aclose = AsyncMock()
+
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            async with SolrSession() as session:
+                await session.query({"q": "test1"})
+                await session.query({"q": "test2"})
+                await session.query({"q": "test3"})
+
+        assert get_count == 1, "Homepage should be fetched once"
+        assert post_count == 3, "Three queries should produce three POSTs"
+
+    @pytest.mark.asyncio
+    async def test_session_not_entered_raises(self):
+        session = SolrSession()
+        with pytest.raises(RuntimeError, match="not entered"):
+            await session.query({"q": "test"})
+
+    @pytest.mark.asyncio
+    async def test_solr_query_with_session(self):
+        """solr_query(params, session=session) should delegate to session.query."""
+        async def mock_get(url, **kwargs):
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        async def mock_post(url, content=None, **kwargs):
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            resp.json = MagicMock(return_value=_make_solr_response([_civile_doc()]))
+            return resp
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.aclose = AsyncMock()
+
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            from src.lib.italgiure.client import solr_query as sq
+            async with SolrSession() as session:
+                result = await sq({"q": "test"}, session=session)
+
+        assert result["response"]["docs"][0]["numdec"] == "24003"
+
+    @pytest.mark.asyncio
+    async def test_solr_query_without_session_backward_compat(self):
+        """solr_query(params) without session should still work (backward compat)."""
+        mock_client = _mock_httpx_client(solr_resp=_make_solr_response([_civile_doc()]))
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            from src.lib.italgiure.client import solr_query as sq
+            result = await sq({"q": "test"})
+        assert result["response"]["numFound"] == 1
+
+
+# ---------------------------------------------------------------------------
+# build_search_params — campo
+# ---------------------------------------------------------------------------
+
+class TestBuildSearchParamsCampo:
+    def test_default_tutto(self):
+        p = build_search_params("test")
+        assert "ocrdis^5" in p["qf"]
+        assert "ocr^1" in p["qf"]
+
+    def test_campo_dispositivo_qf(self):
+        p = build_search_params("test", campo="dispositivo")
+        assert p["qf"] == "ocrdis^1"
+        assert "ocr^" not in p["qf"]
+
+    def test_campo_dispositivo_pf(self):
+        p = build_search_params("test", campo="dispositivo")
+        assert p["pf"] == "ocrdis^3"
+        assert "ocr^" not in p["pf"]
+
+    def test_campo_dispositivo_pf2(self):
+        p = build_search_params("test", campo="dispositivo")
+        assert p["pf2"] == "ocrdis^2"
+
+    def test_campo_dispositivo_pf3(self):
+        p = build_search_params("test", campo="dispositivo")
+        assert p["pf3"] == "ocrdis^1"
+
+
+# ---------------------------------------------------------------------------
+# build_search_params — include_facets
+# ---------------------------------------------------------------------------
+
+class TestBuildSearchParamsFacets:
+    def test_no_facets_by_default(self):
+        p = build_search_params("test")
+        assert "facet" not in p
+
+    def test_facets_enabled(self):
+        p = build_search_params("test", include_facets=True)
+        assert p["facet"] == "true"
+        assert "materia" in p["facet.field"]
+        assert "szdec" in p["facet.field"]
+        assert "anno" in p["facet.field"]
+        assert "tipoprov" in p["facet.field"]
+        assert p["facet.limit"] == 10
+        assert p["facet.mincount"] == 1
+
+    def test_score_in_fl(self):
+        p = build_search_params("test")
+        assert "score" in p["fl"]
+
+
+# ---------------------------------------------------------------------------
+# build_search_params — mm override
+# ---------------------------------------------------------------------------
+
+class TestBuildSearchParamsMmOverride:
+    def test_default_mm(self):
+        p = build_search_params("test")
+        assert p["mm"] == "2<75% 5<60%"
+
+    def test_mm_override(self):
+        p = build_search_params("test", mm="100%")
+        assert p["mm"] == "100%"
+
+
+# ---------------------------------------------------------------------------
+# build_explore_params
+# ---------------------------------------------------------------------------
+
+class TestBuildExploreParams:
+    def test_rows_zero(self):
+        p = build_explore_params("test")
+        assert p["rows"] == 0
+
+    def test_facets_enabled(self):
+        p = build_explore_params("test")
+        assert p["facet"] == "true"
+        assert "materia" in p["facet.field"]
+
+    def test_campo_tutto(self):
+        p = build_explore_params("test", campo="tutto")
+        assert "ocr^1" in p["qf"]
+
+    def test_campo_dispositivo(self):
+        p = build_explore_params("test", campo="dispositivo")
+        assert p["qf"] == "ocrdis^1"
+        assert "ocr^" not in p["qf"]
+
+    def test_archivio_civile(self):
+        p = build_explore_params("test", archivio="civile")
+        fq_str = " ".join(p["fq"]) if isinstance(p["fq"], list) else p["fq"]
+        assert 'kind:"snciv"' in fq_str
+        assert "snpen" not in fq_str
+
+    def test_fl_minimal(self):
+        p = build_explore_params("test")
+        assert p["fl"] == "id"
+
+
+# ---------------------------------------------------------------------------
+# format_facets
+# ---------------------------------------------------------------------------
+
+class TestFormatFacets:
+    def test_basic_formatting(self):
+        facet_counts = {
+            "facet_fields": {
+                "materia": ["contratti", 45, "responsabilità", 23],
+                "szdec": ["3", 30, "1", 20, "SU", 8],
+                "anno": ["2024", 25, "2023", 15],
+                "tipoprov": ["S", 40, "O", 15],
+            }
+        }
+        result = format_facets(facet_counts, 15432)
+        assert "15432 totali" in result
+        assert "contratti (45)" in result
+        assert "III (30)" in result  # szdec mapped
+        assert "SS.UU. (8)" in result  # SU mapped
+        assert "sentenza (40)" in result  # tipoprov mapped
+        assert "ordinanza (15)" in result
+
+    def test_empty_facets(self):
+        result = format_facets({}, 0)
+        assert result == ""
+
+    def test_empty_facet_fields(self):
+        result = format_facets({"facet_fields": {}}, 100)
+        assert result == ""
+
+    def test_partial_facets(self):
+        facet_counts = {
+            "facet_fields": {
+                "materia": ["contratti", 10],
+            }
+        }
+        result = format_facets(facet_counts, 10)
+        assert "Materia" in result
+        assert "contratti (10)" in result
+        assert "Sezione" not in result  # szdec not present
+
+    def test_section_mapping(self):
+        facet_counts = {
+            "facet_fields": {
+                "szdec": ["L", 5, "T", 3, "U", 2],
+            }
+        }
+        result = format_facets(facet_counts, 10)
+        assert "lav. (5)" in result
+        assert "trib. (3)" in result
+        assert "sez. un. (2)" in result
+
+    def test_tipoprov_mapping(self):
+        facet_counts = {
+            "facet_fields": {
+                "tipoprov": ["D", 7],
+            }
+        }
+        result = format_facets(facet_counts, 7)
+        assert "decreto (7)" in result
+
+
+# ---------------------------------------------------------------------------
+# Score filtering
+# ---------------------------------------------------------------------------
+
+class TestScoreFiltering:
+    def test_basic_threshold(self):
+        docs = [
+            {"id": "1", "score": 10.0},
+            {"id": "2", "score": 8.0},
+            {"id": "3", "score": 1.5},  # 15% of max, below 20%
+        ]
+        filtered, dropped = _filter_by_score(docs)
+        assert len(filtered) == 2
+        assert dropped == 1
+        assert all(d["id"] in ("1", "2") for d in filtered)
+
+    def test_all_above_threshold(self):
+        docs = [
+            {"id": "1", "score": 10.0},
+            {"id": "2", "score": 5.0},
+            {"id": "3", "score": 3.0},
+        ]
+        filtered, dropped = _filter_by_score(docs)
+        assert len(filtered) == 3
+        assert dropped == 0
+
+    def test_no_score_passthrough(self):
+        docs = [{"id": "1"}, {"id": "2"}]
+        filtered, dropped = _filter_by_score(docs)
+        assert len(filtered) == 2
+        assert dropped == 0
+
+    def test_empty_list(self):
+        filtered, dropped = _filter_by_score([])
+        assert filtered == []
+        assert dropped == 0
+
+    def test_zero_max_score(self):
+        docs = [{"id": "1", "score": 0.0}]
+        filtered, dropped = _filter_by_score(docs)
+        assert len(filtered) == 1
+        assert dropped == 0
+
+    def test_exact_threshold(self):
+        """Score exactly at 20% of max should be kept."""
+        docs = [
+            {"id": "1", "score": 10.0},
+            {"id": "2", "score": 2.0},  # exactly 20%
+        ]
+        filtered, dropped = _filter_by_score(docs)
+        assert len(filtered) == 2
+        assert dropped == 0
+
+
+# ---------------------------------------------------------------------------
+# Modalità esplora
+# ---------------------------------------------------------------------------
+
+class TestModalitaEsplora:
+    @pytest.mark.asyncio
+    async def test_returns_facets_no_docs(self):
+        solr_resp = {
+            "responseHeader": {"status": 0},
+            "response": {"numFound": 15000, "start": 0, "docs": []},
+            "facet_counts": {
+                "facet_fields": {
+                    "materia": ["contratti", 500, "resp. civile", 300],
+                    "szdec": ["3", 200],
+                    "anno": ["2024", 400],
+                    "tipoprov": ["S", 600, "O", 200],
+                }
+            },
+        }
+        mock_client = _mock_httpx_client(solr_resp=solr_resp)
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("responsabilità medica", modalita="esplora")
+        assert "Esplorazione" in result
+        assert "15000" in result
+        assert "Suggerimento" in result
+        assert "contratti" in result
+
+    @pytest.mark.asyncio
+    async def test_esplora_no_results(self):
+        solr_resp = _make_solr_response([], num_found=0)
+        mock_client = _mock_httpx_client(solr_resp=solr_resp)
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("xyz nessun risultato", modalita="esplora")
+        assert "Nessuna" in result
+
+    @pytest.mark.asyncio
+    async def test_esplora_error(self):
+        async def raise_error(*args, **kwargs):
+            raise Exception("timeout")
+
+        mock_client = AsyncMock()
+        mock_client.get = raise_error
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("test", modalita="esplora")
+        assert "Errore" in result
+
+
+# ---------------------------------------------------------------------------
+# Auto-refinement
+# ---------------------------------------------------------------------------
+
+class TestAutoRefinement:
+    def _make_faceted_response(self, docs, num_found):
+        return {
+            "responseHeader": {"status": 0},
+            "response": {"numFound": num_found, "start": 0, "docs": docs},
+            "highlighting": {},
+            "facet_counts": {
+                "facet_fields": {
+                    "materia": ["contratti", num_found],
+                    "szdec": ["3", num_found],
+                    "anno": ["2024", num_found],
+                    "tipoprov": ["S", num_found],
+                }
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_triggers_when_above_threshold(self):
+        """When numFound > 50, auto-refinement should be attempted."""
+        call_count = 0
+
+        async def mock_get(url, **kwargs):
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        async def mock_post(url, content=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            if call_count == 1:
+                # First call: too many results
+                resp.json = MagicMock(return_value=self._make_faceted_response(
+                    [_civile_doc()], 15000
+                ))
+            elif call_count == 2:
+                # Second call (first refinement step mm=100%): success
+                resp.json = MagicMock(return_value=self._make_faceted_response(
+                    [_civile_doc()], 30
+                ))
+            else:
+                resp.json = MagicMock(return_value=self._make_faceted_response([], 0))
+            return resp
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.aclose = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("responsabilità medica")
+
+        assert "Raffinamento automatico" in result
+        assert "15000" in result
+        assert "30" in result
+
+    @pytest.mark.asyncio
+    async def test_no_trigger_below_threshold(self):
+        """When numFound <= 50, no auto-refinement."""
+        doc = _civile_doc()
+        doc["score"] = 10.0
+        solr_resp = {
+            "responseHeader": {"status": 0},
+            "response": {"numFound": 30, "start": 0, "docs": [doc]},
+            "highlighting": {},
+            "facet_counts": {"facet_fields": {}},
+        }
+        mock_client = _mock_httpx_client(solr_resp=solr_resp)
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("test specifico")
+        assert "Raffinamento" not in result
+        assert "Trovate 30" in result
+
+    @pytest.mark.asyncio
+    async def test_no_trigger_with_explicit_filters(self):
+        """Auto-refinement should not trigger when user already applied filters."""
+        call_count = 0
+
+        async def mock_get(url, **kwargs):
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        async def mock_post(url, content=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            doc = _civile_doc()
+            doc["score"] = 10.0
+            resp.json = MagicMock(return_value={
+                "responseHeader": {"status": 0},
+                "response": {"numFound": 200, "start": 0, "docs": [doc]},
+                "highlighting": {},
+                "facet_counts": {"facet_fields": {"materia": ["contratti", 200]}},
+            })
+            return resp
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("test", materia="contratti")
+
+        # Only 1 POST (no refinement calls)
+        assert call_count == 1
+        assert "Raffinamento" not in result
+
+    @pytest.mark.asyncio
+    async def test_early_exit_on_success(self):
+        """Refinement should stop at the first step that works."""
+        call_count = 0
+
+        async def mock_get(url, **kwargs):
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        async def mock_post(url, content=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            if call_count == 1:
+                resp.json = MagicMock(return_value=self._make_faceted_response(
+                    [_civile_doc()], 5000
+                ))
+            else:
+                # First refinement step succeeds
+                resp.json = MagicMock(return_value=self._make_faceted_response(
+                    [_civile_doc()], 20
+                ))
+            return resp
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.aclose = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("test generico")
+
+        assert "Raffinamento automatico" in result
+        # 1 initial + 1 homepage + 1 successful refinement = max 3 posts
+        # (homepage is a GET, so only 2 POSTs expected)
+        assert call_count <= 3
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_best_when_no_step_below_threshold(self):
+        """When no step gets below threshold, use the step with fewest results."""
+        call_count = 0
+
+        async def mock_get(url, **kwargs):
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        async def mock_post(url, content=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = AsyncMock()
+            resp.raise_for_status = MagicMock()
+            if call_count == 1:
+                resp.json = MagicMock(return_value=self._make_faceted_response(
+                    [_civile_doc()], 10000
+                ))
+            elif call_count == 2:
+                resp.json = MagicMock(return_value=self._make_faceted_response(
+                    [_civile_doc()], 500
+                ))
+            elif call_count == 3:
+                resp.json = MagicMock(return_value=self._make_faceted_response(
+                    [_civile_doc()], 200  # Best result
+                ))
+            elif call_count == 4:
+                resp.json = MagicMock(return_value=self._make_faceted_response(
+                    [_civile_doc()], 300
+                ))
+            else:
+                resp.json = MagicMock(return_value=self._make_faceted_response([], 0))
+            return resp
+
+        mock_client = AsyncMock()
+        mock_client.get = mock_get
+        mock_client.post = mock_post
+        mock_client.aclose = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("test ampio")
+
+        assert "Raffinamento automatico" in result
+        assert "200" in result  # Should use the best (200)
+
+
+# ---------------------------------------------------------------------------
+# cerca_giurisprudenza enhanced — campo + modalita + score e2e
+# ---------------------------------------------------------------------------
+
+class TestCercaGiurisprudenzaEnhanced:
+    @pytest.mark.asyncio
+    async def test_campo_dispositivo_passed(self):
+        mock_client, captured = _capturing_mock_client()
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            await _cerca_giurisprudenza_impl("test", campo="dispositivo")
+        body = captured.get("body", "")
+        # qf should only have ocrdis, not ocr
+        assert "ocrdis" in body
+        # In dispositivo mode, qf=ocrdis^1 (no ocr^1)
+        assert "qf=ocrdis" in body
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_defaults(self):
+        """Default campo="tutto" and modalita="cerca" produce same output as before."""
+        doc = _civile_doc()
+        doc["score"] = 10.0
+        solr_resp = {
+            "responseHeader": {"status": 0},
+            "response": {"numFound": 1, "start": 0, "docs": [doc]},
+            "highlighting": {},
+            "facet_counts": {"facet_fields": {}},
+        }
+        mock_client = _mock_httpx_client(solr_resp=solr_resp)
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("test")
+        assert "Trovate" in result
+        assert "Cass. civ." in result
+
+    @pytest.mark.asyncio
+    async def test_score_filtering_applied(self):
+        """Docs with low scores should be filtered out."""
+        docs = [
+            {**_civile_doc("1001", "2024"), "score": 50.0, "id": "doc1"},
+            {**_civile_doc("1002", "2024"), "score": 40.0, "id": "doc2"},
+            {**_civile_doc("1003", "2024"), "score": 1.0, "id": "doc3"},  # Below threshold
+        ]
+        solr_resp = {
+            "responseHeader": {"status": 0},
+            "response": {"numFound": 3, "start": 0, "docs": docs},
+            "highlighting": {},
+            "facet_counts": {"facet_fields": {}},
+        }
+        mock_client = _mock_httpx_client(solr_resp=solr_resp)
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("test")
+        assert "2 ad alta rilevanza" in result
+        assert "1001" in result
+        assert "1002" in result
+
+    @pytest.mark.asyncio
+    async def test_facets_shown_when_many_results(self):
+        """Facets should appear in output when numFound > 50."""
+        doc = _civile_doc()
+        doc["score"] = 10.0
+        solr_resp = {
+            "responseHeader": {"status": 0},
+            "response": {"numFound": 200, "start": 0, "docs": [doc]},
+            "highlighting": {},
+            "facet_counts": {
+                "facet_fields": {
+                    "materia": ["contratti", 100],
+                    "szdec": ["3", 50],
+                    "anno": ["2024", 80],
+                    "tipoprov": ["S", 120],
+                }
+            },
+        }
+        mock_client = _mock_httpx_client(solr_resp=solr_resp)
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            # Use explicit filter to avoid auto-refinement
+            result = await _cerca_giurisprudenza_impl("test", materia="contratti")
+        assert "Distribuzione risultati" in result
+        assert "Suggerimento" in result
+
+    @pytest.mark.asyncio
+    async def test_facets_not_shown_when_few_results(self):
+        """Facets should not appear when numFound <= 50."""
+        doc = _civile_doc()
+        doc["score"] = 10.0
+        solr_resp = {
+            "responseHeader": {"status": 0},
+            "response": {"numFound": 10, "start": 0, "docs": [doc]},
+            "highlighting": {},
+            "facet_counts": {"facet_fields": {"materia": ["contratti", 10]}},
+        }
+        mock_client = _mock_httpx_client(solr_resp=solr_resp)
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            result = await _cerca_giurisprudenza_impl("test specifico")
+        assert "Distribuzione" not in result
+
+    @pytest.mark.asyncio
+    async def test_include_facets_in_params(self):
+        mock_client, captured = _capturing_mock_client()
+        with patch("src.lib.italgiure.client.httpx.AsyncClient", return_value=mock_client):
+            await _cerca_giurisprudenza_impl("test")
+        body = captured.get("body", "")
+        assert "facet=true" in body


### PR DESCRIPTION
## Summary
- **SolrSession**: riuso cookie HTTP per query multiple (1 homepage invece di N)
- **Campo dispositivo**: `campo="dispositivo"` per cercare solo nel dispositivo (più preciso)
- **Modalità esplora**: `modalita="esplora"` restituisce solo distribuzione facet (materia, sezione, anno, tipo) senza documenti
- **Score filtering**: filtra automaticamente doc con score < 20% del massimo
- **Auto-refinement**: quando >50 risultati senza filtri, prova progressivamente mm=100%, dispositivo-only, solo sentenze
- **Facets nell'output**: distribuzione risultati mostrata quando numFound > 50
- **Docstring arricchita**: strategia consigliata, sintassi Solr eDisMax, nota archivio 2020+
- **Bump versione**: 1.1.1 → 1.1.2

## Test plan
- [x] 163 unit test passati (117 esistenti + 46 nuovi)
- [x] 413 test suite completa passata (0 failure)
- [x] Test live: `"responsabilità medica"` → esplora (27 risultati, distribuzione corretta), cerca con auto-refinement (2483 → 5), dispositivo (5)
- [ ] Verificare facets su Italgiure in produzione (graceful fallback se non supportate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)