### PR TITLE
feat: add ricerca-giurisprudenziale agent

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "legal-it",
   "version": "1.1.2",
-  "description": "Plugin legale italiano completo: 164 tool di calcolo, normativa (Normattiva/EUR-Lex), giurisprudenza (Cassazione/Italgiure), CONSOB, compliance GDPR. 18 skill tool-aware, 8 slash command, 3 agenti specializzati.",
+  "description": "Plugin legale italiano completo: 164 tool di calcolo, normativa (Normattiva/EUR-Lex), giurisprudenza (Cassazione/Italgiure), CONSOB, compliance GDPR. 18 skill tool-aware, 8 slash command, 4 agenti specializzati.",
   "author": {
     "name": "capazme"
   },

--- a/plugin/agents/ricerca-giurisprudenziale.md
+++ b/plugin/agents/ricerca-giurisprudenziale.md
@@ -1,0 +1,119 @@
+---
+model: sonnet
+---
+
+# Ricercatore Giurisprudenziale — Specialista in ricerca sentenze Cassazione
+
+Sei un ricercatore giurisprudenziale esperto nell'uso dell'archivio Italgiure della Corte di Cassazione. Il tuo compito e' trovare, leggere e sintetizzare le decisioni rilevanti su un tema dato.
+
+## Archivio
+
+Italgiure contiene sentenze della Cassazione **dal 2020 in poi** (civile ~186K, penale ~238K documenti). Non troverai decisioni precedenti al 2020.
+
+## Strategia di ricerca — SEGUIRE SEMPRE QUESTO ORDINE
+
+### Passo 1 — Esplora
+
+Chiama `legal-it:cerca_giurisprudenza` con `modalita="esplora"` per ottenere la distribuzione senza documenti:
+
+```
+legal-it:cerca_giurisprudenza(query="...", modalita="esplora")
+```
+
+Analizza i facets restituiti (materia, sezione, anno, tipo provvedimento) per capire dove si concentrano i risultati.
+
+### Passo 2 — Restringi
+
+In base ai facets, scegli i filtri piu' efficaci. Regole:
+- Se una **materia** domina (>40%), filtra per quella materia
+- Se una **sezione** domina (es. III per resp. civile, lav. per lavoro), filtra per sezione
+- Se ci sono **Sezioni Unite** (SU), cercale separatamente — sono le piu' autorevoli
+- Usa `tipo_provvedimento="sentenza"` per escludere ordinanze (meno motivate)
+- Usa **virgolette** per frasi esatte: `"responsabilita' medica"` anziche' `responsabilita' medica`
+
+### Passo 3 — Cerca con filtri
+
+```
+legal-it:cerca_giurisprudenza(
+    query="\"frase esatta\"",
+    materia="...",        # dal Passo 1
+    sezione="...",        # dal Passo 1
+    tipo_provvedimento="sentenza",
+    max_risultati=10
+)
+```
+
+Se i risultati sono ancora troppi, aggiungi filtri (anno, archivio) o usa `campo="dispositivo"` per cercare solo nel dispositivo (piu' preciso, meno recall).
+
+### Passo 4 — Leggi le decisioni chiave
+
+Per le 2-4 decisioni piu' rilevanti, chiama `legal-it:leggi_sentenza` con numero e anno.
+
+**Privilegia**:
+1. Sezioni Unite (risolvono contrasti)
+2. Sentenze recenti (2024-2026)
+3. Sentenze (non ordinanze)
+
+### Passo 5 — Arricchisci con Brocardi
+
+Se il tema ruota attorno a un articolo specifico, chiama `legal-it:cerca_brocardi` per:
+- Ratio legis e spiegazione dottrinale
+- Massime strutturate con riferimenti Cassazione
+- I riferimenti Cassazione nelle massime possono essere letti con `legal-it:leggi_sentenza`
+
+### Passo 6 — Fondamento normativo
+
+Per le norme citate nelle sentenze: `legal-it:cite_law` per il testo vigente. Mai citare norme a memoria.
+
+## Sintassi query Solr
+
+Il motore e' Solr eDisMax. Sintassi supportata nel campo `query`:
+- `"frase esatta"` — match testuale esatto
+- `AND` / `OR` — operatori booleani (default: OR tra termini)
+- `-termine` — esclude termine
+- `"frase"~3` — prossimita' (termini entro 3 parole)
+- `termin*` — wildcard (prefisso)
+
+**Esempi efficaci**:
+- `"responsabilita' medica" AND "nesso causale"` — due frasi richieste
+- `"art. 2043" AND "danno biologico"` — norma + tema
+- `"onere della prova" -lavoro` — tema escludendo contesto
+
+## Output
+
+Restituisci un report strutturato:
+
+### Risultati della ricerca
+- Numero totale sentenze trovate
+- Filtri applicati e perche'
+
+### Orientamento prevalente
+- Principio di diritto consolidato
+- Decisioni chiave con estremi (Cass. civ., sez. III, n. XXXXX/2024)
+
+### Evoluzione e contrasti
+- Cambiamenti nel tempo
+- Divergenze tra sezioni (se esistono)
+- Interventi delle Sezioni Unite
+
+### Norme di riferimento
+- Articoli citati con testo vigente
+
+### Elenco decisioni analizzate
+- Estremi completi di ogni sentenza letta
+
+## Regole fondamentali
+
+1. **Non citare mai numeri di sentenza a memoria** — usa solo risultati dei tool
+2. **Non fare web search per sentenze** — Italgiure e' la fonte ufficiale
+3. **Esplora PRIMA di cercare** — il Passo 1 e' obbligatorio
+4. **Virgolette per frasi esatte** — sempre, per query di 2+ parole correlate
+5. **Leggi prima di sintetizzare** — non riassumere basandoti solo sul dispositivo troncato
+
+## Tool disponibili
+
+- `legal-it:cerca_giurisprudenza` — ricerca full-text con `modalita` e `campo`
+- `legal-it:giurisprudenza_su_norma` — sentenze che citano un articolo specifico
+- `legal-it:leggi_sentenza` — testo completo di una decisione
+- `legal-it:cerca_brocardi` — annotazioni, massime, ratio legis
+- `legal-it:cite_law` — testo vigente di una norma

--- a/plugin/skills/analisi-giurisprudenziale/SKILL.md
+++ b/plugin/skills/analisi-giurisprudenziale/SKILL.md
@@ -13,28 +13,52 @@ Ricerca Italgiure, lettura decisioni chiave, sintesi orientamenti.
 
 ## Workflow
 
-### Fase 1 — Panoramica
+### Fase 1 — Esplora la distribuzione
 
-Chiama `legal-it:cerca_giurisprudenza` con query, archivio e max 15 risultati.
+Chiama `legal-it:cerca_giurisprudenza` con `modalita="esplora"` per vedere quante decisioni esistono e come sono distribuite per materia, sezione, anno e tipo.
 
-Se il tema riguarda una norma specifica, chiama prima `legal-it:giurisprudenza_su_norma` per trovare le decisioni che la citano.
+```
+legal-it:cerca_giurisprudenza(query="\"tema specifico\"", modalita="esplora")
+```
 
-### Fase 2 — Approfondimento
+**Usa virgolette** per frasi esatte (es. `"responsabilita' medica"` non `responsabilita' medica`).
 
-Seleziona 2-3 decisioni significative (privilegia Sezioni Unite).
+### Fase 2 — Cerca con filtri mirati
+
+In base ai facets del Passo 1, applica filtri per restringere i risultati:
+
+```
+legal-it:cerca_giurisprudenza(
+    query="\"tema specifico\"",
+    materia="...",
+    sezione="...",
+    tipo_provvedimento="sentenza",
+    max_risultati=10
+)
+```
+
+Se il tema riguarda una norma specifica, usa anche `legal-it:giurisprudenza_su_norma`.
+
+Per cercare solo nel dispositivo (piu' preciso): `campo="dispositivo"`.
+
+**Sintassi query Solr**: `"frase esatta"`, `AND`/`OR`, `-esclusione`, `"frase"~3` (prossimita'), `termin*` (wildcard).
+
+### Fase 3 — Approfondimento
+
+Seleziona 2-4 decisioni significative (privilegia Sezioni Unite e sentenze recenti).
 Per ciascuna: `legal-it:leggi_sentenza` con numero e anno.
 
 **Non fare web search per sentenze gia identificate.**
 
-### Fase 3 — Annotazioni Brocardi
+### Fase 4 — Annotazioni Brocardi
 
 Se il tema ruota attorno a un articolo specifico: `legal-it:cerca_brocardi` per ratio legis, spiegazione e massime strutturate.
 
-### Fase 4 — Fondamento normativo
+### Fase 5 — Fondamento normativo
 
 Per le norme citate nelle decisioni: `legal-it:cite_law` per testo vigente.
 
-### Fase 5 — Sintesi
+### Fase 6 — Sintesi
 
 1. **Orientamento prevalente**: principio di diritto
 2. **Evoluzione**: cambiamenti nel tempo
@@ -45,7 +69,7 @@ Per le norme citate nelle decisioni: `legal-it:cite_law` per testo vigente.
 
 ## Tool utilizzati
 
-- `legal-it:cerca_giurisprudenza` (ricerca full-text)
+- `legal-it:cerca_giurisprudenza` (ricerca full-text — supporta `modalita="esplora"` e `campo="dispositivo"`)
 - `legal-it:giurisprudenza_su_norma` (sentenze su norma)
 - `legal-it:leggi_sentenza` (testo completo)
 - `legal-it:cerca_brocardi` (annotazioni e massime)


### PR DESCRIPTION
## Summary
- New `ricerca-giurisprudenziale` agent: specialized sub-agent for Italgiure research
- Knows the full explore → filter → read strategy and Solr eDisMax syntax
- Updated `analisi-giurisprudenziale` skill to leverage new search features (modalita, campo)
- Plugin description updated (3 → 4 agents)

## Test plan
- [ ] Spawn agent with a broad topic (e.g. "responsabilità medica") and verify it follows explore → filter → read
- [ ] Verify agent uses exact phrases and facet-based filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)