### PR TITLE
docs: align MCP context to Italgiure esplora/filtra features

### DIFF
--- a/plugin/agents/civilista.md
+++ b/plugin/agents/civilista.md
@@ -9,7 +9,12 @@ Sei un avvocato civilista esperto in contratti, responsabilità civile, successi
 ## Regole fondamentali
 
 1. **LEGAL GROUNDING**: Prima di citare QUALSIASI norma, chiama `legal-it:cite_law` per ottenere il testo vigente. Mai citare a memoria.
-2. **Giurisprudenza**: Usa `legal-it:cerca_giurisprudenza` con `archivio="civile"` per trovare precedenti. Poi `legal-it:leggi_sentenza` per il testo integrale.
+2. **Giurisprudenza** (archivio 2020+):
+   - **Prima esplora**: `legal-it:cerca_giurisprudenza(query="\"tema\"", archivio="civile", modalita="esplora")` per la distribuzione
+   - **Poi filtra**: usa materia, sezione, tipo_provvedimento dai facets
+   - **Frasi esatte**: usa virgolette per query di 2+ parole correlate
+   - **Dispositivo**: `campo="dispositivo"` per match più precisi
+   - Poi `legal-it:leggi_sentenza` per il testo integrale.
 3. **Dottrina**: Usa `legal-it:cerca_brocardi` per ratio legis, spiegazione e massime.
 
 ## Struttura delle risposte

--- a/plugin/agents/penalista.md
+++ b/plugin/agents/penalista.md
@@ -9,7 +9,12 @@ Sei un avvocato penalista esperto in reati, pene, prescrizione, misure cautelari
 ## Regole fondamentali
 
 1. **LEGAL GROUNDING**: Prima di citare QUALSIASI norma, chiama `legal-it:cite_law` per ottenere il testo vigente. Mai citare a memoria.
-2. **Giurisprudenza**: Usa `legal-it:cerca_giurisprudenza` con `archivio="penale"` per trovare precedenti penali. Poi `legal-it:leggi_sentenza` per il testo integrale.
+2. **Giurisprudenza** (archivio 2020+):
+   - **Prima esplora**: `legal-it:cerca_giurisprudenza(query="\"tema\"", archivio="penale", modalita="esplora")` per la distribuzione
+   - **Poi filtra**: usa materia, sezione, tipo_provvedimento dai facets
+   - **Frasi esatte**: usa virgolette per query di 2+ parole correlate
+   - **Dispositivo**: `campo="dispositivo"` per match più precisi
+   - Poi `legal-it:leggi_sentenza` per il testo integrale.
 3. **Prescrizione**: Usa SEMPRE `legal-it:prescrizione_reato` per i calcoli — il regime (Bonafede vs Cartabia) dipende dalla data del fatto.
 
 ## Regime di prescrizione

--- a/plugin/commands/ricerca.md
+++ b/plugin/commands/ricerca.md
@@ -5,7 +5,12 @@ description: Ricerca giurisprudenza o normativa su un tema
 
 In base alla richiesta dell'utente, scegli il tipo di ricerca:
 
-**Giurisprudenza**: Usa `legal-it:cerca_giurisprudenza` con la query dell'utente. Presenta i risultati con numero, data, sezione e massima. Per leggere una sentenza specifica, usa `legal-it:leggi_sentenza`.
+**Giurisprudenza** (archivio Cassazione 2020+):
+1. Prima esplora la distribuzione: `legal-it:cerca_giurisprudenza(query="...", modalita="esplora")`
+2. In base ai facets (materia, sezione, anno, tipo), cerca con filtri mirati
+3. Usa virgolette per frasi esatte: `"responsabilità medica"` non `responsabilità medica`
+4. Per match precisi: `campo="dispositivo"`
+5. Per leggere una sentenza: `legal-it:leggi_sentenza`
 
 **Normativa**: Usa `legal-it:cite_law` per le norme individuate. Integra con `legal-it:cerca_brocardi` per annotazioni e massime.
 

--- a/plugin/skills/resources/tool-catalog.md
+++ b/plugin/skills/resources/tool-catalog.md
@@ -19,7 +19,7 @@ Reference completa dei tool disponibili. Ogni skill carica solo questa sezione s
 | Tool | Uso |
 |------|-----|
 | `legal-it:leggi_sentenza` | Testo completo sentenza (numero + anno noti) |
-| `legal-it:cerca_giurisprudenza` | Ricerca full-text nelle sentenze |
+| `legal-it:cerca_giurisprudenza` | Ricerca full-text (archivio 2020+). Parametri chiave: `modalita="esplora"` (solo distribuzione), `campo="dispositivo"` (solo dispositivo), `materia`, `sezione`, `tipo_provvedimento`. Strategia: esplora → filtra → leggi |
 | `legal-it:giurisprudenza_su_norma` | Sentenze che citano un articolo specifico |
 | `legal-it:ultime_pronunce` | Ultime decisioni depositate |
 

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -561,6 +561,10 @@ PROCEDURA:
    - Orientamenti consolidati vs. questioni aperte
    - Posizioni dottrinali prevalenti
 
+   Per trovare giurisprudenza recente (2020+), chiama
+   `cerca_giurisprudenza(query="\"art. ... codice\"", modalita="esplora")`
+   per la distribuzione, poi con filtri per le decisioni più rilevanti.
+
 4. QUADRO SANZIONATORIO
    Se pertinente, identifica:
    - Sanzioni penali (contravvenzioni, delitti)
@@ -840,12 +844,18 @@ ARCHIVIO: {archivio} (civile / penale / tutti)
 
 PROCEDURA:
 
-### Fase 1 — Panoramica degli orientamenti
-Chiama `cerca_giurisprudenza(query="{tema}", archivio="{archivio}", max_risultati=15)` per
-ottenere una panoramica delle decisioni più recenti e rilevanti.
+### Fase 1 — Esplorazione distribuzione
+Chiama `cerca_giurisprudenza(query="\"{tema}\"", archivio="{archivio}", modalita="esplora")`
+per vedere la distribuzione per materia, sezione, anno e tipo provvedimento.
+Usa virgolette per frasi esatte.
 
 Se il tema riguarda una norma specifica (es. "art. 2043 c.c."), chiama prima
 `giurisprudenza_su_norma(riferimento="art. ...")` per trovare le decisioni che la citano.
+
+### Fase 1b — Ricerca con filtri
+In base ai facets, chiama `cerca_giurisprudenza` con filtri mirati (materia, sezione,
+tipo_provvedimento="sentenza", max_risultati=10).
+Per cercare solo nel dispositivo: `campo="dispositivo"`.
 
 ### Fase 2 — Approfondimento decisioni chiave
 Seleziona le 2-3 decisioni più significative (privilegia Sezioni Unite se presenti).

--- a/src/server.py
+++ b/src/server.py
@@ -19,7 +19,7 @@ Strumenti di diritto italiano. Cerca i tool di questo server quando l'utente chi
 - INVESTIMENTI: BOT, BTP, buoni postali, rendimento
 - UTILITÀ: codice fiscale, IBAN, scorporo IVA, patente, alcolemico, ATECO
 - NORMATIVA: cite_law() per testo vigente, Brocardi per dottrina, PDF norme
-- GIURISPRUDENZA: sentenze Cassazione (Italgiure), ricerca full-text
+- GIURISPRUDENZA: sentenze Cassazione (Italgiure, archivio 2020+). Strategia: esplora → filtra → leggi
 - GARANTE PRIVACY: provvedimenti GPDP, ricerca sanzioni, linee guida
 - GDPR/PRIVACY COMPLIANCE: informative privacy (art. 13-14), cookie policy, DPA (art. 28), registro trattamenti (art. 30), DPIA (art. 35), data breach (art. 33-34), sanzioni (art. 83), base giuridica (art. 6)
 - CONSOB: delibere, provvedimenti, regolamenti mercati finanziari, intermediari, abusi di mercato
@@ -30,7 +30,8 @@ OUTPUT: € 1.234,56 | GG/MM/AAAA | segnalare INDICATIVO se stimato.
 WORKFLOW:
 Sinistro → danno_biologico_* → danno_non_patrimoniale → rivalutazione_monetaria → interessi_legali
 Credito → interessi_mora → rivalutazione_monetaria → decreto_ingiuntivo → parcella_avvocato_civile
-Norma → cite_law → cerca_brocardi → cerca_giurisprudenza → leggi_sentenza
+Norma → cite_law → cerca_brocardi → giurisprudenza_su_norma → leggi_sentenza
+Giurisprudenza → cerca_giurisprudenza(modalita="esplora") → cerca_giurisprudenza(filtri) → leggi_sentenza
 Privacy → cite_law (GDPR) → cerca_provvedimenti_garante → leggi_provvedimento_garante
 Compliance GDPR → analisi_base_giuridica → verifica_necessita_dpia → genera_registro_trattamenti → genera_informativa_privacy → genera_dpa
 Data Breach → valutazione_data_breach → genera_notifica_data_breach → calcolo_sanzione_gdpr


### PR DESCRIPTION
## Summary
- Update `instructions` in server.py with esplora→filtra→leggi strategy and dedicated Giurisprudenza workflow
- Update prompts `analisi_giurisprudenziale` (Fase 1 esplora + Fase 1b filtri) and `ricerca_normativa` (sez. 3)
- Update agents `civilista.md` and `penalista.md` with 4-step search strategy
- Expand `cerca_giurisprudenza` entry in tool-catalog.md with new parameters
- Update `ricerca.md` command with 5-step giurisprudenza workflow

## Test plan
- [x] `pytest tests/ -m "not live"` — 413 passed
- [x] `grep "esplora"` confirms presence in server.py, prompts.py
- [x] `grep "modalita"` confirms presence in all 6 plugin files
- [ ] Manual: verify LLM uses esplora strategy when searching case law

🤖 Generated with [Claude Code](https://claude.com/claude-code)