### PR TITLE
Post-Italgiure: align prompts/agents, add resource, health endpoint, CI tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install dependencies
+        run: pip install ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ -m "not live" -q
+
       - name: Build Desktop Extension (.mcpb)
         run: |
           VERSION="${TAG_VERSION#v}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,18 +22,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add comprehensive project documentation and release tooling
 - main (v0.3.0) back into develop
 
-## [0.3.1] - 2026-03-03
-
-### Added
-- overhaul install.py with CLI flags, plugin support, updated profiles
-
-### Fixed
-- use venv python for pytest in release.py
-- marketplace add path should point to repo root, not plugin subdir
-
-### Other
-- feature/update-installer into develop
-- improve release.py with version sync, CHANGELOG, plugin-only mode
-- update installer and mcp config
-- add comprehensive project documentation and release tooling
-- main (v0.3.0) back into develop

--- a/plugin/agents/privacy-specialist.md
+++ b/plugin/agents/privacy-specialist.md
@@ -13,7 +13,11 @@ Sei uno specialista in protezione dei dati personali, esperto in GDPR (Reg. UE 2
    - `legal-it:cite_law("art. X D.Lgs. 196/2003")` per il Codice Privacy italiano
    - `legal-it:cite_law("art. X D.Lgs. 101/2018")` per il decreto di adeguamento
 2. **Provvedimenti Garante**: Usa `legal-it:cerca_provvedimenti_garante` per cercare e `legal-it:leggi_provvedimento_garante` per leggere il testo completo.
-3. **Giurisprudenza**: Usa `legal-it:cerca_giurisprudenza` con query specifiche privacy per la Cassazione.
+3. **Giurisprudenza** (archivio 2020+):
+   - **Prima esplora**: `legal-it:cerca_giurisprudenza(query="\"tema privacy\"", modalita="esplora")` per la distribuzione
+   - **Poi filtra**: usa materia, sezione, tipo_provvedimento dai facets
+   - **Frasi esatte**: virgolette per query di 2+ parole
+   - Poi `legal-it:leggi_sentenza` per il testo integrale.
 
 ## Struttura delle risposte
 

--- a/plugin/agents/ricerca-giurisprudenziale.md
+++ b/plugin/agents/ricerca-giurisprudenziale.md
@@ -65,6 +65,14 @@ Se il tema ruota attorno a un articolo specifico, chiama `legal-it:cerca_brocard
 
 Per le norme citate nelle sentenze: `legal-it:cite_law` per il testo vigente. Mai citare norme a memoria.
 
+### Passo 7 — Cross-reference fonti amministrative (se pertinente)
+
+Se il tema tocca **mercati finanziari** (insider trading, abusi di mercato, OPA, intermediari):
+- `legal-it:cerca_delibere_consob(query="...")` per delibere e sanzioni CONSOB correlate
+
+Se il tema tocca **protezione dati** (data breach, consenso, profilazione, sanzioni privacy):
+- `legal-it:cerca_provvedimenti_garante(query="...")` per provvedimenti del Garante
+
 ## Sintassi query Solr
 
 Il motore e' Solr eDisMax. Sintassi supportata nel campo `query`:

--- a/plugin/skills/resources/tool-catalog.md
+++ b/plugin/skills/resources/tool-catalog.md
@@ -20,7 +20,7 @@ Reference completa dei tool disponibili. Ogni skill carica solo questa sezione s
 |------|-----|
 | `legal-it:leggi_sentenza` | Testo completo sentenza (numero + anno noti) |
 | `legal-it:cerca_giurisprudenza` | Ricerca full-text (archivio 2020+). Parametri chiave: `modalita="esplora"` (solo distribuzione), `campo="dispositivo"` (solo dispositivo), `materia`, `sezione`, `tipo_provvedimento`. Strategia: esplora → filtra → leggi |
-| `legal-it:giurisprudenza_su_norma` | Sentenze che citano un articolo specifico |
+| `legal-it:giurisprudenza_su_norma` | Sentenze che citano un articolo specifico. Parametri: `solo_sezioni_unite`, `anno_da`/`anno_a`, `archivio`. Preferire a `cerca_giurisprudenza` quando si parte da un articolo |
 | `legal-it:ultime_pronunce` | Ultime decisioni depositate |
 
 ## CONSOB

--- a/run_server.py
+++ b/run_server.py
@@ -26,6 +26,24 @@ transport = os.environ.get("MCP_TRANSPORT", "stdio")
 if transport == "sse":
     host = os.environ.get("MCP_HOST", "0.0.0.0")
     port = int(os.environ.get("MCP_PORT", "8000"))
-    mcp.run(transport="sse", host=host, port=port)
+
+    # Mount /health endpoint for liveness probes
+    from starlette.applications import Starlette
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+
+    async def health(request):
+        return PlainTextResponse("ok")
+
+    sse_app = mcp.sse_app()
+    app = Starlette(
+        routes=[Route("/health", health)],
+        on_startup=sse_app.router.on_startup,
+        on_shutdown=sse_app.router.on_shutdown,
+    )
+    app.mount("/", sse_app)
+
+    import uvicorn
+    uvicorn.run(app, host=host, port=port)
 else:
     mcp.run(transport="stdio")

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -283,8 +283,10 @@ Elenca e cita le norme applicabili (testo da cite_law).
 Indica le fonti: legge, regolamento, direttiva UE, etc.
 
 #### 3.2 Orientamento giurisprudenziale
-Se disponibile (tramite cite_law con include_annotations=true),
-riporta gli orientamenti di Cassazione e giurisprudenza di merito.
+Usa `cite_law` con `include_annotations=true` per le massime Brocardi.
+Per giurisprudenza recente (2020+), chiama
+`cerca_giurisprudenza(query="\\"{area_diritto}\\"", modalita="esplora")` per la distribuzione,
+poi con filtri mirati. Leggi le decisioni chiave con `leggi_sentenza`.
 
 #### 3.3 Dottrina
 Se pertinente, menziona le posizioni dottrinali prevalenti.
@@ -939,8 +941,10 @@ Fonti tipiche:
 - MiCA (Reg. UE 2023/1114) — cripto-attività
 
 ### Fase 4 — Giurisprudenza correlata (se pertinente)
-Se le delibere citano pronunce giurisdizionali o se il tema ha risvolti contenziosi,
-chiama `cerca_giurisprudenza(query="{tema}")` per verificare eventuali sentenze.
+Se le delibere citano pronunce giurisdizionali o se il tema ha risvolti contenziosi:
+1. Esplora la distribuzione: `cerca_giurisprudenza(query="\\"{tema}\\"", modalita="esplora")`
+2. Filtra con materia/sezione dai facets, poi `leggi_sentenza` per le decisioni chiave.
+Usa virgolette per frasi esatte.
 
 ### Fase 5 — Sintesi strutturata
 

--- a/src/resources.py
+++ b/src/resources.py
@@ -897,6 +897,17 @@ NORMATIVA DI RIFERIMENTO MERCATI FINANZIARI
 Per il testo di queste norme: usare cite_law("art. N [fonte]").
 
 ═══════════════════════════════════════════════════════════
+CROSS-REFERENCE GIURISPRUDENZA
+═══════════════════════════════════════════════════════════
+
+Per sentenze della Cassazione correlate a temi CONSOB:
+1. cerca_giurisprudenza(query="\"tema\"", modalita="esplora") → distribuzione
+2. Filtra con materia/sezione dai facets
+3. leggi_sentenza(numero, anno) → testo integrale
+
+Vedi risorsa: legal://riferimenti/ricerca-giurisprudenziale
+
+═══════════════════════════════════════════════════════════
 NOTE TECNICHE
 ═══════════════════════════════════════════════════════════
 
@@ -904,4 +915,132 @@ NOTE TECNICHE
 - Le date nei filtri usano formato YYYY-MM-DD (es. "2024-01-01")
 - Il testo delle delibere è troncato a 8000 caratteri per evitare saturazione del contesto
 - La ricerca interroga il Bollettino CONSOB (Liferay Portal) — dati pubblici, nessuna autenticazione
+"""
+
+
+@mcp.resource(
+    "legal://riferimenti/ricerca-giurisprudenziale",
+    name="Ricerca Giurisprudenziale — Guida Italgiure",
+    description="Guida alla ricerca su Italgiure: strategia esplora→filtra→leggi, sintassi Solr, facets e workflow tipo",
+)
+def ricerca_giurisprudenziale() -> str:
+    return """RICERCA GIURISPRUDENZIALE — GUIDA ALL'USO DI ITALGIURE
+(Archivio Cassazione, sentenze dal 2020 in poi)
+
+═══════════════════════════════════════════════════════════
+TOOL DISPONIBILI
+═══════════════════════════════════════════════════════════
+
+| Tool | Uso | Parametri chiave |
+|------|-----|------------------|
+| `cerca_giurisprudenza` | Ricerca full-text | query, modalita, campo, materia, sezione, tipo_provvedimento, archivio, max_risultati |
+| `giurisprudenza_su_norma` | Sentenze su un articolo | riferimento, solo_sezioni_unite, anno_da, anno_a, archivio |
+| `leggi_sentenza` | Testo completo | numero, anno, sezione, archivio |
+| `ultime_pronunce` | Ultime depositate | materia, sezione, archivio |
+
+═══════════════════════════════════════════════════════════
+STRATEGIA: ESPLORA → FILTRA → LEGGI
+═══════════════════════════════════════════════════════════
+
+### Passo 1 — Esplora la distribuzione
+```
+cerca_giurisprudenza(query="\"tema\"", modalita="esplora")
+```
+Restituisce solo i facets (materia, sezione, anno, tipo provvedimento) SENZA documenti.
+Serve per capire dove si concentrano i risultati prima di cercare.
+
+### Passo 2 — Filtra con i facets
+In base alla distribuzione, scegli i filtri:
+- **Materia** dominante (>40%) → filtra per materia
+- **Sezione** dominante (es. III per resp. civile) → filtra per sezione
+- **Sezioni Unite** presenti → cercale separatamente (le più autorevoli)
+- `tipo_provvedimento="sentenza"` → esclude ordinanze (meno motivate)
+
+```
+cerca_giurisprudenza(
+    query="\"tema\"",
+    materia="...",
+    sezione="...",
+    tipo_provvedimento="sentenza",
+    max_risultati=10
+)
+```
+
+### Passo 3 — Leggi le decisioni chiave
+Per le 2-4 decisioni più rilevanti:
+```
+leggi_sentenza(numero=XXXXX, anno=2024)
+```
+Privilegia: Sezioni Unite > sentenze recenti > sentenze (non ordinanze).
+
+═══════════════════════════════════════════════════════════
+SINTASSI QUERY SOLR
+═══════════════════════════════════════════════════════════
+
+Il motore è Solr eDisMax. Sintassi supportata nel campo `query`:
+
+| Sintassi | Effetto | Esempio |
+|----------|---------|---------|
+| `"frase esatta"` | Match testuale esatto | `"responsabilità medica"` |
+| `AND` / `OR` | Operatori booleani (default: OR) | `"art. 2043" AND "danno"` |
+| `-termine` | Esclude termine | `"onere prova" -lavoro` |
+| `"frase"~3` | Prossimità (entro N parole) | `"nesso causale"~5` |
+| `termin*` | Wildcard (prefisso) | `risarcim*` |
+
+REGOLA: usare SEMPRE virgolette per frasi di 2+ parole correlate.
+
+═══════════════════════════════════════════════════════════
+PARAMETRO `campo`
+═══════════════════════════════════════════════════════════
+
+| Valore | Cerca in | Quando usare |
+|--------|----------|--------------|
+| (default) | Testo completo (OCR) | Ricerca ampia |
+| `"dispositivo"` | Solo dispositivo | Più preciso, meno recall |
+
+═══════════════════════════════════════════════════════════
+FACETS DISPONIBILI
+═══════════════════════════════════════════════════════════
+
+| Facet | Descrizione | Esempio valori |
+|-------|-------------|----------------|
+| Materia | Area giuridica | Obbligazioni, Lavoro, Famiglia |
+| Sezione | Sezione della Corte | I, II, III, lav., SU |
+| Anno | Anno di deposito | 2020, 2021, ..., 2026 |
+| Tipo provvedimento | Tipo decisione | sentenza, ordinanza |
+
+═══════════════════════════════════════════════════════════
+ARCHIVI
+═══════════════════════════════════════════════════════════
+
+| Archivio | Collezione Solr | Documenti |
+|----------|----------------|-----------|
+| `civile` | snciv | ~186K |
+| `penale` | snpen | ~238K |
+| `tutti` (default) | entrambi | ~424K |
+
+═══════════════════════════════════════════════════════════
+WORKFLOW TIPO
+═══════════════════════════════════════════════════════════
+
+Ricerca su tema:
+1. cerca_giurisprudenza(query="\"tema\"", modalita="esplora")
+2. Analizza facets → scegli filtri
+3. cerca_giurisprudenza(query="\"tema\"", materia="...", sezione="...", max_risultati=10)
+4. leggi_sentenza(numero, anno) per le 2-3 decisioni chiave
+5. cite_law("art. ...") per le norme citate
+
+Ricerca su norma specifica:
+1. giurisprudenza_su_norma(riferimento="art. 2043 c.c.")
+2. leggi_sentenza(numero, anno) per le decisioni chiave
+3. cerca_brocardi("art. 2043 c.c.") per massime e dottrina
+
+═══════════════════════════════════════════════════════════
+NOTE TECNICHE
+═══════════════════════════════════════════════════════════
+
+- API: Solr REST su italgiure.giustizia.it (pubblica, nessuna autenticazione)
+- OCR troncato a 30000 caratteri per evitare saturazione contesto
+- Certificato SSL non valido → verify=False (necessario)
+- Campi chiave: numdec (numero), anno, datdep (data deposito), szdec (sezione), ocr (testo)
 """

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,0 +1,57 @@
+"""Regression tests for prompt keyword presence.
+
+Ensures that prompts referencing giurisprudenza include the esplora/filtra
+strategy terms introduced in the Italgiure alignment.
+"""
+
+import pytest
+
+from src.prompts import (
+    analisi_giurisprudenziale,
+    ricerca_normativa,
+    analisi_delibere_consob,
+    parere_legale,
+)
+
+
+def _get_prompt_text(fn, **kwargs):
+    """Call a prompt function and return the generated text."""
+    inner = getattr(fn, "fn", fn)
+    return inner(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "prompt_fn,kwargs,expected_terms",
+    [
+        pytest.param(
+            analisi_giurisprudenziale,
+            {"tema": "test", "archivio": "tutti"},
+            ["esplora", "modalita", "filtri"],
+            id="analisi_giurisprudenziale",
+        ),
+        pytest.param(
+            ricerca_normativa,
+            {"tema": "test", "area_diritto": "civile"},
+            ["esplora"],
+            id="ricerca_normativa",
+        ),
+        pytest.param(
+            analisi_delibere_consob,
+            {"tema": "test"},
+            ["esplora"],
+            id="analisi_delibere_consob",
+        ),
+        pytest.param(
+            parere_legale,
+            {"area_diritto": "civile", "quesito": "test"},
+            ["cerca_giurisprudenza"],
+            id="parere_legale",
+        ),
+    ],
+)
+def test_prompt_contains_keywords(prompt_fn, kwargs, expected_terms):
+    text = _get_prompt_text(prompt_fn, **kwargs)
+    for term in expected_terms:
+        assert term in text, (
+            f"Prompt '{prompt_fn.__name__}' missing keyword '{term}'"
+        )


### PR DESCRIPTION
## Summary

- **Prompts**: `analisi_delibere_consob` Fase 4 e `parere_legale` sez. 3.2 ora usano strategia esplora→filtra→leggi
- **Agents**: `privacy-specialist` e `ricerca-giurisprudenziale` allineati (esplora strategy + cross-reference CONSOB/Garante)
- **Tool catalog**: `giurisprudenza_su_norma` arricchito con parametri disponibili
- **Risorsa**: nuova `legal://riferimenti/ricerca-giurisprudenziale` — guida completa Italgiure
- **CHANGELOG**: rimosso entry duplicato `0.3.1`
- **Test**: 4 test di regressione sui prompt (keyword presence)
- **CI**: step `pytest` aggiunto al workflow release (fail-fast)
- **Health**: endpoint `/health` per deploy SSE (Starlette wrapper)

## Test plan

- [x] `pytest tests/ -m "not live" -q` — 417 passed
- [x] `pytest tests/unit/test_prompts.py -v` — 4/4 passed
- [ ] Verify `/health` endpoint: `MCP_TRANSPORT=sse MCP_PORT=9999 python run_server.py` + `curl localhost:9999/health`
- [ ] Verify new resource loads: `legal://riferimenti/ricerca-giurisprudenziale`

🤖 Generated with [Claude Code](https://claude.com/claude-code)