### PR TITLE
release: v1.3.2 — fix MCP dist config (uv → pip)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legal-it",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Plugin legale italiano completo: 166 tool di calcolo, normativa (Normattiva/EUR-Lex), giurisprudenza (Cassazione/Italgiure), CONSOB, compliance GDPR, generazione atti (100 tipi). 19 skill, 8 slash command, 5 agenti specializzati.",
   "author": {
     "name": "capazme"

--- a/plugin/.mcp.dist.json
+++ b/plugin/.mcp.dist.json
@@ -1,11 +1,10 @@
 {
   "mcpServers": {
     "legal-it": {
-      "command": "uv",
+      "command": "bash",
       "args": [
-        "run",
-        "--project", "${CLAUDE_PLUGIN_ROOT}/server",
-        "python", "${CLAUDE_PLUGIN_ROOT}/server/run_server.py"
+        "-c",
+        "cd \"${CLAUDE_PLUGIN_ROOT}/server\" && pip install -q -e . 2>/dev/null; python run_server.py"
       ],
       "env": {
         "MCP_CACHE_DIR": "${HOME}/.cache/mcp-legal-it",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-legal-it"
-version = "1.3.1"
+version = "1.3.2"
 description = "MCP server with 166 Italian legal tools: calculations, legislation, case law, CONSOB, GDPR, document generation"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Fix: replace uv with pip+python in .mcp.dist.json for plugin installation on machines without uv.