### PR TITLE
release: v1.3.3 — bootstrap script for zero-dep installation

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legal-it",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Plugin legale italiano completo: 166 tool di calcolo, normativa (Normattiva/EUR-Lex), giurisprudenza (Cassazione/Italgiure), CONSOB, compliance GDPR, generazione atti (100 tipi). 19 skill, 8 slash command, 5 agenti specializzati.",
   "author": {
     "name": "capazme"

--- a/plugin/.mcp.dist.json
+++ b/plugin/.mcp.dist.json
@@ -3,8 +3,7 @@
     "legal-it": {
       "command": "bash",
       "args": [
-        "-c",
-        "cd \"${CLAUDE_PLUGIN_ROOT}/server\" && pip install -q -e . 2>/dev/null; python run_server.py"
+        "${CLAUDE_PLUGIN_ROOT}/start_server.sh"
       ],
       "env": {
         "MCP_CACHE_DIR": "${HOME}/.cache/mcp-legal-it",

--- a/plugin/start_server.sh
+++ b/plugin/start_server.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bootstrap script: ensures dependencies are installed, then starts the MCP server.
+# Called by Claude Code via .mcp.json — works on any machine with Python 3.10+.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVER="$DIR/server"
+VENV="$SERVER/.venv"
+
+# Create venv and install deps on first run (cached after that)
+if [ ! -f "$VENV/bin/python" ]; then
+  python3 -m venv "$VENV" 2>/dev/null
+  "$VENV/bin/pip" install -q --disable-pip-version-check \
+    "fastmcp>=2.0.0" "httpx>=0.27" "beautifulsoup4>=4.12" "lxml>=5.0" "fpdf2>=2.7"
+fi
+
+exec "$VENV/bin/python" "$SERVER/run_server.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-legal-it"
-version = "1.3.2"
+version = "1.3.3"
 description = "MCP server with 166 Italian legal tools: calculations, legislation, case law, CONSOB, GDPR, document generation"
 requires-python = ">=3.10"
 dependencies = [

--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -23,6 +23,8 @@ cp -r "$ROOT_DIR/plugin/agents" "$BUILD_DIR/agents"
 cp -r "$ROOT_DIR/plugin/commands" "$BUILD_DIR/commands"
 cp -r "$ROOT_DIR/plugin/hooks" "$BUILD_DIR/hooks"
 cp "$ROOT_DIR/plugin/settings.json" "$BUILD_DIR/"
+cp "$ROOT_DIR/plugin/start_server.sh" "$BUILD_DIR/"
+chmod +x "$BUILD_DIR/start_server.sh"
 
 # Use distributable .mcp.json (with ${CLAUDE_PLUGIN_ROOT} paths)
 cp "$ROOT_DIR/plugin/.mcp.dist.json" "$BUILD_DIR/.mcp.json"


### PR DESCRIPTION
start_server.sh creates venv + installs deps automatically. Works on office machines with only Python 3.10+.