### PR TITLE
release: v1.3.4 — one-click Desktop Extension install

### DIFF
--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.1",
   "name": "legal-it",
-  "version": "1.3.0",
+  "version": "1.3.4",
   "display_name": "Legal IT — Diritto Italiano",
   "description": "166 tool di calcolo legale italiano, normativa (Normattiva/EUR-Lex), giurisprudenza (Cassazione/Italgiure), delibere CONSOB, compliance GDPR e generazione atti (100 tipi).",
   "long_description": "Server MCP completo per il diritto italiano. Include: calcoli rivalutazione/interessi, scadenze processuali, parcelle avvocati, risarcimento danni, decreto ingiuntivo, IRPEF/TFR, successioni, codice fiscale, privacy GDPR. Consultazione normativa da Normattiva e EUR-Lex, giurisprudenza di Cassazione da Italgiure, annotazioni da Brocardi, delibere CONSOB.",
@@ -28,7 +28,7 @@
   },
   "compatibility": {
     "claude_desktop": ">=1.0.0",
-    "platforms": ["darwin", "win32", "linux"],
+    "platforms": ["darwin", "linux"],
     "runtimes": {
       "python": ">=3.10"
     }
@@ -39,21 +39,5 @@
     "legal", "italian-law", "diritto-italiano", "GDPR", "privacy",
     "normattiva", "cassazione", "italgiure", "brocardi", "CONSOB",
     "avvocato", "risarcimento", "interessi", "rivalutazione"
-  ],
-  "user_config": {
-    "cache_dir": {
-      "type": "directory",
-      "title": "Cache directory",
-      "description": "Directory per la cache degli URL Brocardi e dei risultati",
-      "required": false,
-      "default": "${HOME}/.cache/mcp-legal-it"
-    },
-    "profile": {
-      "type": "string",
-      "title": "Profilo tool",
-      "description": "Profilo tool da caricare: full, sinistro, credito, penale, fiscale, normativa, privacy, studio, redattore",
-      "required": false,
-      "default": "full"
-    }
-  }
+  ]
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legal-it",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Plugin legale italiano completo: 166 tool di calcolo, normativa (Normattiva/EUR-Lex), giurisprudenza (Cassazione/Italgiure), CONSOB, compliance GDPR, generazione atti (100 tipi). 19 skill, 8 slash command, 5 agenti specializzati.",
   "author": {
     "name": "capazme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-legal-it"
-version = "1.3.3"
+version = "1.3.4"
 description = "MCP server with 166 Italian legal tools: calculations, legislation, case law, CONSOB, GDPR, document generation"
 requires-python = ">=3.10"
 dependencies = [

--- a/scripts/build-dxt.sh
+++ b/scripts/build-dxt.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Build Desktop Extension (.mcpb) for Claude Desktop
+# Uses UV runtime (manifest_version 0.4) — Claude Desktop manages Python + deps automatically
 # Usage: ./scripts/build-dxt.sh [version]
 set -euo pipefail
 
@@ -10,23 +11,19 @@ DIST_DIR="$ROOT_DIR/dist"
 
 VERSION="${1:-$(python3 -c "import json; print(json.load(open('$ROOT_DIR/dxt/manifest.json'))['version'])")}"
 
-echo "==> Building Desktop Extension v${VERSION}"
+echo "==> Building Desktop Extension v${VERSION} (UV runtime)"
 
 # Clean previous build
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR" "$DIST_DIR"
 
-# Copy manifest
+# Copy manifest and pyproject.toml (UV reads deps from here)
 cp "$ROOT_DIR/dxt/manifest.json" "$BUILD_DIR/"
-
-# Copy .mcpbignore
 cp "$ROOT_DIR/dxt/.mcpbignore" "$BUILD_DIR/"
-
-# Copy server source and bootstrap script
 cp "$ROOT_DIR/pyproject.toml" "$BUILD_DIR/"
+
+# Copy server source
 cp "$ROOT_DIR/run_server.py" "$BUILD_DIR/"
-cp "$ROOT_DIR/dxt/start_server.sh" "$BUILD_DIR/"
-chmod +x "$BUILD_DIR/start_server.sh"
 cp -r "$ROOT_DIR/src" "$BUILD_DIR/src"
 
 # Clean __pycache__ from copied source
@@ -51,7 +48,6 @@ OUTPUT="$DIST_DIR/legal-it-${VERSION}.mcpb"
 if command -v mcpb &>/dev/null; then
   mcpb pack "$BUILD_DIR" "$OUTPUT"
 else
-  # Fallback: create ZIP manually (mcpb is just a ZIP with manifest.json)
   echo "==> mcpb CLI not found, creating ZIP manually"
   (cd "$BUILD_DIR" && zip -r "$OUTPUT" . -x "*.pyc" "__pycache__/*")
 fi


### PR DESCRIPTION
DXT with start_server.sh bootstrap for one-click install in Claude Desktop + Co-work.