### PR TITLE
chore: route security reports and questions off the issue tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,21 @@
+# Configures the chooser shown at /issues/new/choose.
+# The bug_report.md and feature_request.md templates appear automatically;
+# these entries add destinations OUTSIDE the issue tracker.
+#
+# This is routing, not enforcement: /issues/new still bypasses the chooser.
+# blank_issues_enabled stays true on purpose — a first-time user whose problem
+# fits neither template should be able to report it anyway rather than give up.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Segnalare una vulnerabilità (privato)
+    url: https://github.com/capazme/mcp-legal-it/security/advisories/new
+    about: Segnalazione privata al maintainer, non visibile pubblicamente. Non aprire una issue per problemi di sicurezza — usa questo canale.
+
+  - name: Domanda sull'uso dei tool
+    url: https://github.com/capazme/mcp-legal-it/discussions/new?category=q-a
+    about: Come si usa un tool, come si legge un output, problemi di installazione o configurazione del plugin. Le domande vanno qui, non nelle issue.
+
+  - name: Idee e proposte di nuovi tool
+    url: https://github.com/capazme/mcp-legal-it/discussions/new?category=ideas
+    about: Proposte da discutere prima che diventino una feature request — nuove fonti, nuovi calcoli, nuovi modelli di atti.


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/config.yml` so the New Issue chooser offers three destinations outside the tracker:

| Card | Goes to |
|---|---|
| Segnalare una vulnerabilità (privato) | `/security/advisories/new` — private report to the maintainer |
| Domanda sull'uso dei tool | Discussions → Q&A |
| Idee e proposte di nuovi tool | Discussions → Ideas |

**Private vulnerability reporting is now enabled** on the repository, so the advisory link resolves. Without it that card would have been a dead end — worse than no card, since it tells the reporter not to open a public issue and then offers nothing that works. Issue #25 arrived as a public issue labelled `enhancement` precisely because no private channel existed.

`blank_issues_enabled` stays `true` deliberately. Closing the blank-issue escape hatch forces a first-time reporter whose problem fits neither template to mis-file it or give up; with traffic incoming, a confused report is worth more than a lost one. Worth revisiting only if the tracker actually fills with noise.

This is routing, not enforcement — `/issues/new` still bypasses the chooser.

### Note on where this has to land

GitHub reads issue-template config from the **default branch** (`main`). Merging this to `develop` alone changes nothing until the next release. The file is repo metadata, not shipped code: neither `build-plugin.sh` nor `build-dxt.sh` copies `.github/`, so it cannot affect any user's install or the release artifacts.

### Verification

```
YAML parses, only the two valid keys present, all three contact_links have name/url/about
All three URLs resolve (no 404), including the advisory form
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)