### PR TITLE
fix: usufruct floor + data-driven resources (CU, interessi, IRPEF) watched by the freshness check

### DIFF
--- a/plugin/server/src/data/usufrutto_coefficienti.json
+++ b/plugin/server/src/data/usufrutto_coefficienti.json
@@ -1,6 +1,7 @@
 {
-  "_description": "Coefficienti per calcolo valore usufrutto/nuda proprietà — Prospetto allegato DPR 131/1986, aggiornato con tasso legale 2.50%",
-  "_note": "Il coefficiente va ricalcolato quando cambia il tasso legale. Valore usufrutto = rendita annua * coefficiente. Nuda proprietà = valore pieno - usufrutto.",
+  "_description": "Coefficienti per calcolo valore usufrutto/nuda proprietà — Prospetto allegato DPR 131/1986, calcolati sul tasso applicabile 2,5%",
+  "_note": "Ai fini del calcolo non può essere assunto un tasso inferiore al 2,5% (D.Lgs. 139/2015): finché il tasso legale resta sotto tale soglia (2025: 2,0%; 2026: 1,6%) valgono i coefficienti basati sul 2,5%, confermati annualmente dal decreto direttoriale MEF di fine dicembre (ultimo: 24/12/2025). Se il tasso legale supera il 2,5%, aggiornare tasso_legale e coefficienti dal prospetto allegato al DM e bumpare anno_verifica (alimenta scripts/update-data.py). Valore usufrutto = valore piena proprietà × tasso × coefficiente.",
+  "anno_verifica": 2026,
   "tasso_legale": 2.5,
   "coefficienti": [
     {"eta_min": 0, "eta_max": 20, "coefficiente": 38.00},

--- a/plugin/server/src/resources.py
+++ b/plugin/server/src/resources.py
@@ -219,27 +219,31 @@ NOTE
 
 @mcp.resource(
     "legal://riferimenti/irpef-detrazioni",
-    name="IRPEF 2025-2026 — Scaglioni e Detrazioni",
+    name="IRPEF 2026 — Scaglioni e Detrazioni",
     description="Schema IRPEF vigente: scaglioni, aliquote e principali detrazioni",
 )
 def irpef_detrazioni() -> str:
-    return """IRPEF 2025-2026 — SCAGLIONI, ALIQUOTE E DETRAZIONI PRINCIPALI
-(D.Lgs. 216/2023 — Riforma fiscale, confermato dalla Legge di Bilancio 2025)
+    return """IRPEF 2026 — SCAGLIONI, ALIQUOTE E DETRAZIONI PRINCIPALI
+(D.Lgs. 216/2023 — Riforma fiscale; L. 199/2025 — Legge di Bilancio 2026)
 
 ═══════════════════════════════════════════════════════════
-SCAGLIONI E ALIQUOTE (dal 2024)
+SCAGLIONI E ALIQUOTE (dal 2026)
 ═══════════════════════════════════════════════════════════
 
 | Scaglione di reddito | Aliquota | Imposta su scaglione |
 |----------------------|----------|---------------------|
 | Fino a € 28.000 | 23% | max € 6.440 |
-| Da € 28.001 a € 50.000 | 35% | max € 7.700 |
+| Da € 28.001 a € 50.000 | 33% | max € 7.260 |
 | Oltre € 50.000 | 43% | — |
 
-Imposta lorda = 23% su primi € 28.000 + 35% su fascia € 28.001-50.000 + 43% sull'eccedente
+Imposta lorda = 23% su primi € 28.000 + 33% su fascia € 28.001-50.000 + 43% sull'eccedente
 
 Esempio: reddito € 60.000
-→ € 6.440 + € 7.700 + 43% × € 10.000 = € 6.440 + € 7.700 + € 4.300 = € 18.440
+→ € 6.440 + € 7.260 + 43% × € 10.000 = € 6.440 + € 7.260 + € 4.300 = € 18.000
+
+Nota: nel 2024-2025 l'aliquota del secondo scaglione era il 35% (max € 7.700).
+La riduzione al 33% (L. 199/2025, art. 1, c. 3) è neutralizzata per i redditi
+complessivi oltre € 200.000 tramite una corrispondente riduzione delle detrazioni.
 
 ═══════════════════════════════════════════════════════════
 DETRAZIONI PER LAVORO DIPENDENTE (art. 13 TUIR)

--- a/plugin/server/src/resources.py
+++ b/plugin/server/src/resources.py
@@ -1,6 +1,53 @@
-"""MCP Resources — 15 static legal reference documents."""
+"""MCP Resources — 15 legal reference documents.
+
+Resources whose figures live in src/data (contributo unificato, interessi
+legali, scaglioni IRPEF) are rendered from those JSON files at read time,
+so they stay aligned with the datasets watched by scripts/update-data.py.
+"""
+
+import json
+from pathlib import Path
 
 from src.server import mcp
+
+_DATA = Path(__file__).parent / "data"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_DATA / name).read_text())
+
+
+def _eur(value: float) -> str:
+    """1214 -> '1.214,00' (Italian amount formatting)."""
+    return f"{value:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+
+def _soglia(value: float) -> str:
+    """Threshold formatting: integers without decimals (1.100), floats with (2.582,28)."""
+    if float(value) == int(value):
+        return f"{int(value):,}".replace(",", ".")
+    return _eur(value)
+
+
+def _pct(value: float) -> str:
+    """2.5 -> '2,50'."""
+    return f"{value:.2f}".replace(".", ",")
+
+
+def _scaglioni_rows(scaglioni: list) -> list:
+    """Markdown rows for a list of {fino_a|oltre, importo} brackets."""
+    rows = []
+    prev = None
+    for s in scaglioni:
+        if s.get("oltre"):
+            label = f"Oltre € {_soglia(prev)}"
+        elif prev is None:
+            label = f"Fino a € {_soglia(s['fino_a'])}"
+        else:
+            label = f"Da € {_soglia(prev + 0.01)} a € {_soglia(s['fino_a'])}"
+        rows.append(f"| {label} | € {_eur(s['importo'])} |")
+        prev = s.get("fino_a", prev)
+    return rows
 
 
 @mcp.resource(
@@ -143,14 +190,53 @@ MEDIAZIONE E NEGOZIAZIONE ASSISTITA
 """
 
 
-@mcp.resource(
-    "legal://riferimenti/contributo-unificato",
-    name="Contributo Unificato — Tabella Scaglioni",
-    description="Scaglioni del contributo unificato per valore causa e tipo procedimento (aggiornato 2025)",
-)
-def contributo_unificato() -> str:
-    return """CONTRIBUTO UNIFICATO — TABELLA SCAGLIONI
-(D.P.R. 115/2002 e successive modifiche — aggiornamento 2025)
+def _render_contributo_unificato() -> str:
+    cu = _load("contributo_unificato.json")
+    civ = cu["civile"]
+
+    cognizione = _scaglioni_rows(civ["cognizione"])
+    cognizione.append(
+        f"| Valore indeterminabile (bassa complessità) | € {_eur(civ['valore_indeterminabile'])} |"
+    )
+    cognizione.append(
+        f"| Valore indeterminabile (alta complessità) | € {_eur(civ['cognizione'][-1]['importo'])} |"
+    )
+
+    monitorio = _scaglioni_rows(civ["procedimento_monitorio"]["scaglioni"])
+
+    speciali = [
+        f"| Opposizione a decreto ingiuntivo | CU pieno per valore |",
+        f"| Procedimenti cautelari | € {_eur(civ['cautelari'])} |",
+        f"| Volontaria giurisdizione | € {_eur(civ['volontaria_giurisdizione'])} |",
+        f"| Procedimenti esecutivi immobiliari | € {_eur(civ['esecuzione_immobiliare'])} |",
+        f"| Procedimenti esecutivi mobiliari | € {_eur(civ['esecuzione_mobiliare'])} |",
+        f"| Separazione consensuale / divorzio congiunto | € {_eur(civ['separazione_consensuale'])} |",
+        f"| Separazione giudiziale / divorzio giudiziale | € {_eur(civ['separazione_giudiziale'])} |",
+    ]
+
+    lav = cu["lavoro"]["appello"]
+    tributario = _scaglioni_rows(cu["tributario"]["scaglioni"])
+
+    amm_labels = {
+        "tar_ordinario": "TAR — rito ordinario",
+        "tar_appalti": "TAR — appalti",
+        "tar_appalti_sopra_soglia": "TAR — appalti sopra soglia",
+        "consiglio_stato": "Consiglio di Stato — ordinario",
+        "consiglio_stato_appalti": "Consiglio di Stato — appalti",
+        "decreto_ingiuntivo_tar": "Decreto ingiuntivo TAR",
+        "silenzio_inadempimento": "Silenzio-inadempimento",
+        "accesso_atti": "Accesso agli atti",
+        "ottemperanza": "Giudizio di ottemperanza",
+    }
+    amministrativo = [
+        f"| {label} | € {_eur(cu['amministrativo'][key])} |"
+        for key, label in amm_labels.items()
+        if key in cu["amministrativo"]
+    ]
+
+    nl = "\n"
+    return f"""CONTRIBUTO UNIFICATO — TABELLA SCAGLIONI
+(D.P.R. 115/2002 e successive modifiche — importi generati da src/data/contributo_unificato.json)
 
 ═══════════════════════════════════════════════════════════
 PROCESSI CIVILI ORDINARI (art. 13, co. 1)
@@ -158,15 +244,15 @@ PROCESSI CIVILI ORDINARI (art. 13, co. 1)
 
 | Valore causa | CU |
 |--------------|-----|
-| Fino a € 1.100 | € 43,00 |
-| Da € 1.100,01 a € 5.200 | € 98,00 |
-| Da € 5.200,01 a € 26.000 | € 237,00 |
-| Da € 26.000,01 a € 52.000 | € 518,00 |
-| Da € 52.000,01 a € 260.000 | € 759,00 |
-| Da € 260.000,01 a € 520.000 | € 1.214,00 |
-| Oltre € 520.000 | € 1.686,00 |
-| Valore indeterminabile (bassa complessità) | € 518,00 |
-| Valore indeterminabile (alta complessità) | € 1.686,00 |
+{nl.join(cognizione)}
+
+═══════════════════════════════════════════════════════════
+PROCEDIMENTO MONITORIO — decreto ingiuntivo (dimezzato)
+═══════════════════════════════════════════════════════════
+
+| Valore causa | CU |
+|--------------|-----|
+{nl.join(monitorio)}
 
 ═══════════════════════════════════════════════════════════
 IMPUGNAZIONI (art. 13, co. 1-bis)
@@ -174,8 +260,8 @@ IMPUGNAZIONI (art. 13, co. 1-bis)
 
 | Grado | Maggiorazione |
 |-------|---------------|
-| Appello | CU × 1,5 (50% in più) |
-| Cassazione | CU × 2 (raddoppio) |
+| Appello | CU × {_pct(cu["appello"]["moltiplicatore"]).rstrip("0").rstrip(",")} ({cu["appello"]["_note"]}) |
+| Cassazione | CU × {_pct(cu["cassazione"]["moltiplicatore"]).rstrip("0").rstrip(",")} ({cu["cassazione"]["_note"]}) |
 | Riassunzione dopo cassazione con rinvio | come primo grado |
 
 ═══════════════════════════════════════════════════════════
@@ -184,28 +270,32 @@ PROCEDIMENTI SPECIALI (art. 13, co. 1 e 3)
 
 | Procedimento | CU |
 |--------------|-----|
-| Decreto ingiuntivo | 50% del CU ordinario (dimezzato) |
-| Opposizione a decreto ingiuntivo | CU pieno per valore |
-| Procedimenti cautelari autonomi | € 98,00 |
-| Volontaria giurisdizione | € 98,00 |
-| Procedimenti di sfratto | € 98,00 |
-| Procedimenti esecutivi immobiliari | € 278,00 |
-| Procedimenti esecutivi mobiliari | € 43 (valore < € 2.500) / € 139 (valore ≥ € 2.500) |
-| Separazione/divorzio consensuale | € 43,00 |
-| Separazione/divorzio giudiziale | € 98,00 (se senza domande economiche) |
+{nl.join(speciali)}
 
 ═══════════════════════════════════════════════════════════
-ESENZIONI E RIDUZIONI
+LAVORO E TRIBUTARIO
 ═══════════════════════════════════════════════════════════
 
-| Fattispecie | Regime |
-|-------------|--------|
-| Cause di lavoro e previdenza (< € 2.500) | Esente |
-| Cause di lavoro e previdenza (> € 2.500) | Esente (solo primo grado) |
-| Procedimenti in materia tavolare | € 98,00 |
-| Controversie ex art. 615 c.p.c. (opp. esecuzione) | CU per valore |
-| Controversie previdenziali | Esente (salvo impugnazioni) |
-| Separazione/divorzio negoziazione assistita | Esente |
+| Fattispecie | CU |
+|-------------|-----|
+| Lavoro e previdenza — primo grado | Esente |
+| Lavoro — appello (fino a € {_soglia(lav["fino_a"])}) | € {_eur(lav["importo"])} |
+| Lavoro — appello (fino a € 50.000) | € {_eur(lav["fino_a_50000"])} |
+| Lavoro — appello (oltre € 50.000) | € {_eur(lav["oltre"])} |
+
+Processo tributario (per valore della lite):
+
+| Valore lite | CU |
+|-------------|-----|
+{nl.join(tributario)}
+
+═══════════════════════════════════════════════════════════
+PROCESSO AMMINISTRATIVO
+═══════════════════════════════════════════════════════════
+
+| Ricorso | CU |
+|---------|-----|
+{nl.join(amministrativo)}
 
 ═══════════════════════════════════════════════════════════
 NOTE
@@ -218,32 +308,70 @@ NOTE
 
 
 @mcp.resource(
-    "legal://riferimenti/irpef-detrazioni",
-    name="IRPEF 2026 — Scaglioni e Detrazioni",
-    description="Schema IRPEF vigente: scaglioni, aliquote e principali detrazioni",
+    "legal://riferimenti/contributo-unificato",
+    name="Contributo Unificato — Tabella Scaglioni",
+    description="Scaglioni del contributo unificato per valore causa e tipo procedimento (generati dal dataset corrente)",
 )
-def irpef_detrazioni() -> str:
-    return """IRPEF 2026 — SCAGLIONI, ALIQUOTE E DETRAZIONI PRINCIPALI
-(D.Lgs. 216/2023 — Riforma fiscale; L. 199/2025 — Legge di Bilancio 2026)
+def contributo_unificato() -> str:
+    return _render_contributo_unificato()
+
+
+def _render_irpef_scaglioni() -> str:
+    per_anno = _load("irpef_scaglioni.json")["scaglioni_per_anno"]
+    anno = max(per_anno.keys(), key=int)
+    scaglioni = per_anno[anno]
+
+    rows = []
+    quote = []
+    prev = 0
+    for s in scaglioni:
+        if s.get("oltre"):
+            rows.append(f"| Oltre € {_soglia(prev)} | {s['aliquota']}% | — |")
+        else:
+            label = (
+                f"Fino a € {_soglia(s['fino_a'])}"
+                if prev == 0
+                else f"Da € {_soglia(prev + 1)} a € {_soglia(s['fino_a'])}"
+            )
+            quota = (s["fino_a"] - prev) * s["aliquota"] / 100
+            quote.append(quota)
+            rows.append(f"| {label} | {s['aliquota']}% | max € {_eur(quota)} |")
+            prev = s["fino_a"]
+
+    aliquota_top = scaglioni[-1]["aliquota"]
+    esempio_reddito = 60000
+    eccedenza = esempio_reddito - prev
+    quota_top = eccedenza * aliquota_top / 100
+    totale = sum(quote) + quota_top
+    somma = " + ".join(f"€ {_eur(q)}" for q in quote)
+
+    nl = "\n"
+    return f"""IRPEF {anno} — SCAGLIONI, ALIQUOTE E DETRAZIONI PRINCIPALI
+(D.Lgs. 216/2023 — Riforma fiscale; scaglioni {anno} generati da src/data/irpef_scaglioni.json)
 
 ═══════════════════════════════════════════════════════════
-SCAGLIONI E ALIQUOTE (dal 2026)
+SCAGLIONI E ALIQUOTE ({anno})
 ═══════════════════════════════════════════════════════════
 
 | Scaglione di reddito | Aliquota | Imposta su scaglione |
 |----------------------|----------|---------------------|
-| Fino a € 28.000 | 23% | max € 6.440 |
-| Da € 28.001 a € 50.000 | 33% | max € 7.260 |
-| Oltre € 50.000 | 43% | — |
+{nl.join(rows)}
 
-Imposta lorda = 23% su primi € 28.000 + 33% su fascia € 28.001-50.000 + 43% sull'eccedente
+Esempio: reddito € {_soglia(esempio_reddito)}
+→ {somma} + {aliquota_top}% × € {_soglia(eccedenza)} = € {_eur(totale)}
+"""
 
-Esempio: reddito € 60.000
-→ € 6.440 + € 7.260 + 43% × € 10.000 = € 6.440 + € 7.260 + € 4.300 = € 18.000
 
+@mcp.resource(
+    "legal://riferimenti/irpef-detrazioni",
+    name="IRPEF — Scaglioni e Detrazioni",
+    description="Schema IRPEF vigente: scaglioni (generati dal dataset corrente), aliquote e principali detrazioni",
+)
+def irpef_detrazioni() -> str:
+    return _render_irpef_scaglioni() + """
 Nota: nel 2024-2025 l'aliquota del secondo scaglione era il 35% (max € 7.700).
-La riduzione al 33% (L. 199/2025, art. 1, c. 3) è neutralizzata per i redditi
-complessivi oltre € 200.000 tramite una corrispondente riduzione delle detrazioni.
+La riduzione al 33% dal 2026 (L. 199/2025, art. 1, c. 3) è neutralizzata per i
+redditi complessivi oltre € 200.000 tramite una corrispondente riduzione delle detrazioni.
 
 ═══════════════════════════════════════════════════════════
 DETRAZIONI PER LAVORO DIPENDENTE (art. 13 TUIR)
@@ -304,61 +432,49 @@ ADDIZIONALI
 """
 
 
-@mcp.resource(
-    "legal://riferimenti/interessi-legali",
-    name="Storico Tassi Interessi Legali",
-    description="Tassi di interesse legale dal 2000 al 2026 (art. 1284 c.c.)",
-)
-def interessi_legali() -> str:
-    return """INTERESSI LEGALI — STORICO TASSI (art. 1284 c.c.)
+def _render_interessi_legali() -> str:
+    legali = _load("tassi_legali.json")["tassi"]
+    mora = _load("tassi_mora.json")["tassi"]
+
+    def _data_it(iso: str) -> str:
+        return f"{iso[8:10]}/{iso[5:7]}/{iso[0:4]}"
+
+    legali_rows = [
+        f"| {_data_it(t['dal'])} | {_data_it(t['al'])} | {_pct(t['tasso'])}% |" for t in legali
+    ]
+    ultimo = max(legali, key=lambda t: t["al"])
+    fonte_ultimo = ultimo.get("fonte", "DM MEF di dicembre")
+
+    mora_rows = [
+        f"| {'I' if t['dal'][5:7] == '01' else 'II'} sem. {t['dal'][0:4]} "
+        f"| {_pct(t['bce'])}% | {_pct(t['mora'])}% |"
+        for t in mora[-8:]
+    ]
+
+    nl = "\n"
+    return f"""INTERESSI LEGALI — STORICO TASSI (art. 1284 c.c.)
 Decreto ministeriale annuale del Ministero dell'Economia e delle Finanze
+Tasso vigente: {_pct(ultimo["tasso"])}% (dal {_data_it(ultimo["dal"])} — {fonte_ultimo})
+Tabelle generate da src/data/tassi_legali.json e tassi_mora.json
 
 ═══════════════════════════════════════════════════════════
-TASSI ANNUALI
+TASSI PER PERIODO (dal 1942)
 ═══════════════════════════════════════════════════════════
 
-| Anno | Tasso | Decreto |
-|------|-------|---------|
-| 2000 | 2,50% | D.M. 10/12/1999 |
-| 2001 | 3,50% | D.M. 11/12/2000 |
-| 2002 | 3,00% | D.M. 11/12/2001 |
-| 2003 | 3,00% | — (invariato) |
-| 2004 | 2,50% | D.M. 01/12/2003 |
-| 2005 | 2,50% | — (invariato) |
-| 2006 | 2,50% | — (invariato) |
-| 2007 | 2,50% | — (invariato) |
-| 2008 | 3,00% | D.M. 12/12/2007 |
-| 2009 | 3,00% | — (invariato) |
-| 2010 | 1,00% | D.M. 04/12/2009 |
-| 2011 | 1,50% | D.M. 07/12/2010 |
-| 2012 | 2,50% | D.M. 12/12/2011 |
-| 2013 | 2,50% | — (invariato) |
-| 2014 | 1,00% | D.M. 12/12/2013 |
-| 2015 | 0,50% | D.M. 11/12/2014 |
-| 2016 | 0,20% | D.M. 11/12/2015 |
-| 2017 | 0,10% | D.M. 07/12/2016 |
-| 2018 | 0,30% | D.M. 13/12/2017 |
-| 2019 | 0,80% | D.M. 12/12/2018 |
-| 2020 | 0,05% | D.M. 12/12/2019 |
-| 2021 | 0,01% | D.M. 11/12/2020 |
-| 2022 | 1,25% | D.M. 13/12/2021 |
-| 2023 | 5,00% | D.M. 13/12/2022 |
-| 2024 | 2,50% | D.M. 11/12/2023 |
-| 2025 | 2,00% | D.M. 10/12/2024 |
-| 2026 | 1,60% | D.M. 10/12/2025 |
+| Dal | Al | Tasso |
+|-----|-----|-------|
+{nl.join(legali_rows)}
 
 ═══════════════════════════════════════════════════════════
 INTERESSI DI MORA (D.Lgs. 231/2002 — transazioni commerciali)
 ═══════════════════════════════════════════════════════════
 
 Tasso = tasso BCE + 8 punti percentuali (art. 5, D.Lgs. 231/2002)
+Ultimi semestri:
 
 | Semestre | Tasso BCE | Tasso mora |
 |----------|-----------|------------|
-| II sem. 2024 | 4,25% | 12,25% |
-| I sem. 2025 | 3,15% | 11,15% |
-| II sem. 2025 | 2,15% | 10,15% |
-| I sem. 2026 | 2,15% | 10,15% |
+{nl.join(mora_rows)}
 
 ═══════════════════════════════════════════════════════════
 NOTE APPLICATIVE
@@ -373,6 +489,15 @@ NOTE APPLICATIVE
 - Rivalutazione vs. interessi: non cumulabili sullo stesso importo
   (Cass. SS.UU. 16601/2017) — il creditore sceglie la via più favorevole
 """
+
+
+@mcp.resource(
+    "legal://riferimenti/interessi-legali",
+    name="Storico Tassi Interessi Legali e Mora",
+    description="Tassi di interesse legale dal 1942 a oggi e saggi di mora (generati dai dataset correnti)",
+)
+def interessi_legali() -> str:
+    return _render_interessi_legali()
 
 
 @mcp.resource(

--- a/scripts/update-data.py
+++ b/scripts/update-data.py
@@ -13,6 +13,8 @@ Data files checked:
 - irpef_scaglioni.json: IRPEF brackets, updated annually (legge di bilancio)
 - tabella_danno_bio.json: art. 139 CAP micropermanenti amounts, revalued
   annually by MIMIT decree (tracked via micropermanenti.anno_ultimo_dm)
+- usufrutto_coefficienti.json: usufruct coefficients — legal rate with a
+  2.5% floor (D.Lgs. 139/2015), confirmed by the December MEF decree
 
 Staleness windows are calibrated on the official publication calendars AND
 on the monthly cron (1st of each month, data-freshness.yml): a window
@@ -36,6 +38,11 @@ TASSI_LEGALI_SOURCE = "https://www.mef.gov.it/it/atti-normative/Decreti-Minister
 TASSI_MORA_SOURCE = "https://www.mef.gov.it/it/atti-normative/Decreti-Ministeriali/"
 IRPEF_SOURCE = "https://www.gazzettaufficiale.it (legge di bilancio, GU di fine dicembre)"
 DANNO_BIO_SOURCE = "https://www.mimit.gov.it/it/normativa/decreti-ministeriali"
+USUFRUTTO_SOURCE = "https://www.finanze.gov.it (decreto direttoriale annuale, fine dicembre)"
+
+# Floor rate for usufruct/annuity computations (D.Lgs. 139/2015): below this
+# the 2.5%-based coefficient table stays valid regardless of the legal rate.
+USUFRUTTO_FLOOR = 2.5
 
 GREEN = "\033[92m"
 YELLOW = "\033[93m"
@@ -263,6 +270,48 @@ def check_danno_bio(today: date) -> bool:
     return False
 
 
+def check_usufrutto(today: date) -> bool:
+    """Returns True if stale.
+
+    A legal-rate drop below the 2.5% floor does not invalidate the table.
+    Stale when the current legal rate exceeds the floor but differs from
+    the rate the table was built on (new prospetto annexed to the December
+    DM), or when the annual MEF confirmation has not been acknowledged
+    (anno_verifica behind, flagged from Feb 1 — January is grace for the
+    late-December decreto direttoriale).
+    """
+    path = DATA_DIR / "usufrutto_coefficienti.json"
+    data = json.loads(path.read_text())
+    tasso_tabella = data["tasso_legale"]
+    anno_verifica = data["anno_verifica"]
+
+    legali = json.loads((DATA_DIR / "tassi_legali.json").read_text())["tassi"]
+    tasso_corrente = max(legali, key=lambda t: t["al"])["tasso"]
+    tasso_richiesto = max(tasso_corrente, USUFRUTTO_FLOOR)
+
+    rate_mismatch = tasso_tabella != tasso_richiesto
+    behind = anno_verifica < today.year
+    is_stale = rate_mismatch or (behind and today >= date(today.year, 2, 1))
+
+    print(f"\n{BOLD}Coefficienti usufrutto — DPR 131/1986 (pavimento 2,5%){RESET}")
+    print(f"  Tabella basata su: {tasso_tabella}% (verificata {anno_verifica})")
+    print(f"  Tasso legale     : {tasso_corrente}% → applicabile {tasso_richiesto}%")
+
+    if is_stale:
+        if rate_mismatch:
+            print(stale(f"Coefficienti calcolati al {tasso_tabella}% ma tasso applicabile {tasso_richiesto}% — servono i coefficienti del nuovo DM"))
+        else:
+            print(stale(f"Conferma annuale {today.year} non recepita (decreto direttoriale MEF di fine dicembre)"))
+        print(f"  Fonte : {USUFRUTTO_SOURCE}")
+        print(f"  Azione: aggiornare src/data/usufrutto_coefficienti.json (coefficienti, tasso_legale, anno_verifica)")
+        return True
+    if behind:
+        print(warn(f"Conferma annuale {today.year} da recepire — finestra di grazia fino al 1° febbraio"))
+        return False
+    print(ok(f"Tabella al {tasso_tabella}% valida (tasso legale {tasso_corrente}% sotto il pavimento)" if tasso_corrente < USUFRUTTO_FLOOR else f"Tabella allineata al tasso {tasso_tabella}%"))
+    return False
+
+
 def main() -> int:
     strict = "--strict" in sys.argv
     today = date.today()
@@ -277,6 +326,7 @@ def main() -> int:
         check_tassi_mora(today),
         check_irpef(today),
         check_danno_bio(today),
+        check_usufrutto(today),
     ]
 
     stale_count = sum(stale_flags)

--- a/tests/unit/test_resources_dynamic.py
+++ b/tests/unit/test_resources_dynamic.py
@@ -1,0 +1,117 @@
+"""Tests binding the data-driven resources to the src/data JSON files.
+
+Expectations are computed from the same JSONs the renderers read, so these
+tests prove the binding (a value changed in the dataset shows up in the
+resource) without pinning any specific year or rate.
+"""
+
+import json
+from pathlib import Path
+
+import src.resources as res
+
+_DATA = Path(__file__).parents[2] / "src" / "data"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_DATA / name).read_text())
+
+
+# --- contributo unificato -------------------------------------------------
+
+
+def test_cu_civil_brackets_come_from_dataset():
+    out = res._render_contributo_unificato()
+    cognizione = _load("contributo_unificato.json")["civile"]["cognizione"]
+    assert f"€ {res._eur(cognizione[0]['importo'])}" in out
+    assert f"€ {res._eur(cognizione[-1]['importo'])}" in out
+    assert f"Oltre € {res._soglia(cognizione[-2]['fino_a'])}" in out
+
+
+def test_cu_monitorio_and_tributario_tables_present():
+    out = res._render_contributo_unificato()
+    cu = _load("contributo_unificato.json")
+    assert f"€ {res._eur(cu['civile']['procedimento_monitorio']['scaglioni'][0]['importo'])}" in out
+    # tributario has a decimal threshold (2582.28) — exercises _soglia float path
+    assert f"€ {res._soglia(cu['tributario']['scaglioni'][0]['fino_a'])}" in out
+
+
+def test_cu_cautelari_matches_dataset_not_old_prose():
+    # The old hardcoded prose said €98.00 while the dataset (used by the
+    # tools) says otherwise: the resource must follow the dataset.
+    out = res._render_contributo_unificato()
+    cautelari = _load("contributo_unificato.json")["civile"]["cautelari"]
+    assert f"| Procedimenti cautelari | € {res._eur(cautelari)} |" in out
+
+
+def test_cu_static_notes_preserved():
+    out = res._render_contributo_unificato()
+    assert "Marca da bollo" in out
+
+
+# --- interessi legali / mora ----------------------------------------------
+
+
+def test_interessi_current_rate_from_dataset():
+    out = res._render_interessi_legali()
+    legali = _load("tassi_legali.json")["tassi"]
+    ultimo = max(legali, key=lambda t: t["al"])
+    assert f"Tasso vigente: {res._pct(ultimo['tasso'])}%" in out
+
+
+def test_interessi_table_covers_full_history():
+    out = res._render_interessi_legali()
+    primo = _load("tassi_legali.json")["tassi"][0]
+    assert f"{primo['dal'][8:10]}/{primo['dal'][5:7]}/{primo['dal'][0:4]}" in out
+
+
+def test_mora_latest_semester_from_dataset():
+    out = res._render_interessi_legali()
+    latest = _load("tassi_mora.json")["tassi"][-1]
+    sem = "I" if latest["dal"][5:7] == "01" else "II"
+    row = (
+        f"| {sem} sem. {latest['dal'][0:4]} "
+        f"| {res._pct(latest['bce'])}% | {res._pct(latest['mora'])}% |"
+    )
+    assert row in out
+
+
+def test_interessi_static_notes_preserved():
+    out = res._render_interessi_legali()
+    assert "anatocismo" in out
+
+
+# --- IRPEF ----------------------------------------------------------------
+
+
+def test_irpef_heading_follows_latest_dataset_year():
+    out = res._render_irpef_scaglioni()
+    anno = max(_load("irpef_scaglioni.json")["scaglioni_per_anno"], key=int)
+    assert f"IRPEF {anno} — SCAGLIONI" in out
+
+
+def test_irpef_rates_come_from_dataset():
+    out = res._render_irpef_scaglioni()
+    per_anno = _load("irpef_scaglioni.json")["scaglioni_per_anno"]
+    scaglioni = per_anno[max(per_anno, key=int)]
+    for s in scaglioni:
+        assert f"| {s['aliquota']}% |" in out
+
+
+def test_irpef_example_total_recomputed():
+    out = res._render_irpef_scaglioni()
+    per_anno = _load("irpef_scaglioni.json")["scaglioni_per_anno"]
+    scaglioni = per_anno[max(per_anno, key=int)]
+    prev, totale = 0, 0.0
+    for s in scaglioni:
+        if s.get("oltre"):
+            totale += (60000 - prev) * s["aliquota"] / 100
+        else:
+            totale += (s["fino_a"] - prev) * s["aliquota"] / 100
+            prev = s["fino_a"]
+    assert f"= € {res._eur(totale)}" in out
+
+
+def test_irpef_static_detrazioni_tail_preserved():
+    out = res.irpef_detrazioni.fn() if hasattr(res.irpef_detrazioni, "fn") else res.irpef_detrazioni()
+    assert "DETRAZIONI PER LAVORO DIPENDENTE" in out

--- a/tests/unit/test_update_data.py
+++ b/tests/unit/test_update_data.py
@@ -150,3 +150,41 @@ def test_danno_bio_stale_from_september(data_dir):
 def test_danno_bio_fresh_when_current_dm_recepito(data_dir):
     _write(data_dir, "tabella_danno_bio.json", _danno_bio(2026))
     assert ud.check_danno_bio(date(2026, 9, 1)) is False
+
+
+# --- Usufrutto: 2.5% floor (D.Lgs. 139/2015) + annual confirmation --------
+
+
+def _usufrutto_fixtures(data_dir: Path, tasso_legale: float, tabella: float, anno: int) -> None:
+    _write(
+        data_dir,
+        "tassi_legali.json",
+        {"tassi": [{"dal": "2026-01-01", "al": "2026-12-31", "tasso": tasso_legale}]},
+    )
+    _write(
+        data_dir,
+        "usufrutto_coefficienti.json",
+        {"tasso_legale": tabella, "anno_verifica": anno, "coefficienti": []},
+    )
+
+
+def test_usufrutto_valid_below_floor(data_dir):
+    # Legal rate 1.6% is under the 2.5% floor: the 2.5% table stays valid.
+    _usufrutto_fixtures(data_dir, tasso_legale=1.6, tabella=2.5, anno=2026)
+    assert ud.check_usufrutto(date(2026, 7, 30)) is False
+
+
+def test_usufrutto_stale_when_rate_above_floor_diverges(data_dir):
+    _usufrutto_fixtures(data_dir, tasso_legale=3.0, tabella=2.5, anno=2026)
+    assert ud.check_usufrutto(date(2026, 7, 30)) is True
+
+
+def test_usufrutto_fresh_when_table_matches_rate_above_floor(data_dir):
+    _usufrutto_fixtures(data_dir, tasso_legale=3.0, tabella=3.0, anno=2026)
+    assert ud.check_usufrutto(date(2026, 7, 30)) is False
+
+
+def test_usufrutto_annual_confirmation_grace_then_stale(data_dir):
+    _usufrutto_fixtures(data_dir, tasso_legale=1.6, tabella=2.5, anno=2025)
+    assert ud.check_usufrutto(date(2026, 1, 15)) is False
+    assert ud.check_usufrutto(date(2026, 2, 1)) is True


### PR DESCRIPTION
Follow-up to #28, from the audit of the remaining data files.

## Commit 1 — usufruct floor metadata + stale IRPEF resource
**usufrutto_coefficienti.json** — the table is *correct* (2.5% floor ex D.Lgs. 139/2015: with the legal rate at 1.6% for 2026 the 2.5%-based coefficients stay valid, confirmed by the MEF decreto direttoriale of 24/12/2025 — see FiscoOggi/Agenzia Entrate), but the metadata claimed "aggiornato con tasso legale 2.50%" as if stuck at 2024. Now documents the floor and carries anno_verifica.
**update-data.py** — new check_usufrutto: fires when the legal rate rises above the floor and diverges from the table, or when the annual December confirmation is not acknowledged (from Feb 1). 7 monitored files total.
**resources.py** — IRPEF resource still showed the 35% second bracket: fixed to 2026 (33%, L. 199/2025).

## Commit 2 — resources rendered from the datasets
The contributo-unificato, interessi-legali and irpef-detrazioni resources embedded prose copies of figures that had silently drifted (CU cautelari: prose €98 vs dataset €147 used by the tools; interessi: mora table stopped at H1 2026; IRPEF: the 35% just fixed by hand). They now render from src/data JSONs at read time — aligned by construction with the datasets watched by update-data.py and auto-refreshed monthly. Bonus: the CU resource gains lavoro/tributario/amministrativo tables the prose lacked; the interessi resource now covers 1942–today and cites the GU source of the current rate. 12 new binding tests.

Verification: full suite **2414 passed**; `update-data.py --strict` exit 0; rendered output eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)