### PR TITLE
fix(release): never roll back local state after a successful push

### DIFF
--- a/release.py
+++ b/release.py
@@ -126,19 +126,41 @@ def fatal(msg: str) -> None:
     sys.exit(1)
 
 
-def ask(prompt: str, default: str = "") -> str:
+_NON_INTERACTIVE = False
+
+
+def set_non_interactive(value: bool) -> None:
+    """All prompts return their default without reading stdin (--non-interactive)."""
+    global _NON_INTERACTIVE
+    _NON_INTERACTIVE = bool(value)
+
+
+def ask(prompt: str, default: str = "", unattended_default: str | None = None) -> str:
+    """Prompt with a default. `unattended_default`, when set, is the answer used
+    whenever stdin is unavailable (--non-interactive or EOF) instead of `default`
+    — for prompts whose interactive default is too permissive to auto-apply."""
+    fallback = default if unattended_default is None else unattended_default
+    if _NON_INTERACTIVE:
+        return fallback
     suffix = f" [{default}]" if default else ""
     try:
         answer = input(f"  {c(BOLD, '?')} {prompt}{suffix}: ").strip()
-    except (EOFError, KeyboardInterrupt):
+    except EOFError:
+        # Piped/closed stdin: degrade to the fallback. Exiting here is unsafe —
+        # a SystemExit inside a RollbackContext would trigger rollback even
+        # after a successful push (observed in the v2.11.0 release).
         print()
-        sys.exit(0)
+        return fallback
+    except KeyboardInterrupt:
+        print()
+        sys.exit(130)
     return answer or default
 
 
-def ask_yes_no(prompt: str, default: bool = True) -> bool:
+def ask_yes_no(prompt: str, default: bool = True, unattended: bool | None = None) -> bool:
     hint = "S/n" if default else "s/N"
-    answer = ask(f"{prompt} ({hint})", "s" if default else "n")
+    unattended_str = None if unattended is None else ("s" if unattended else "n")
+    answer = ask(f"{prompt} ({hint})", "s" if default else "n", unattended_default=unattended_str)
     return answer.lower() in ("s", "si", "sì", "y", "yes")
 
 
@@ -725,9 +747,14 @@ class RollbackContext:
     def __init__(self, *, dry_run: bool):
         self._stack: list[tuple[str, callable]] = []
         self._dry_run = dry_run
+        self._armed = True
 
     def register(self, description: str, fn: callable) -> None:
         self._stack.append((description, fn))
+
+    def disarm(self) -> None:
+        """Stop rolling back: the release is on origin, local undo would only diverge."""
+        self._armed = False
 
     def __enter__(self):
         return self
@@ -736,6 +763,8 @@ class RollbackContext:
         if exc_type is None:
             return False
         if self._dry_run:
+            return False
+        if not self._armed:
             return False
         print()
         error(f"Errore durante la release: {exc_val}")
@@ -760,6 +789,11 @@ class RollbackContext:
 
 def interactive_setup() -> argparse.Namespace:
     """Gather release parameters interactively."""
+    if not sys.stdin.isatty():
+        fatal(
+            "Modalità interattiva richiede un terminale (stdin non è una TTY). "
+            "Per esecuzioni automatiche: release.py X.Y.Z --from-develop [--push] [--non-interactive]"
+        )
     print()
     print(c(BOLD, "  MCP Legal IT — Release interattiva"))
     print(c(DIM, "  " + "-" * 55))
@@ -986,6 +1020,34 @@ def interactive_setup() -> argparse.Namespace:
     )
 
 
+def _push_release(rb: RollbackContext, *, dry: bool, branches: tuple[str, ...],
+                  tag: str, release_branch: str | None) -> None:
+    """Push the release to origin (shared by --from-develop and --tag-only).
+
+    The FIRST successful branch push is the point of no return: origin already
+    has the release commits, so any later failure (tag push, cleanup) must NOT
+    trigger the local rollback — it would only diverge local from remote.
+    """
+    label = " e ".join(branches)
+    step(f"Push branch {label} su origin")
+    run_git("push", "origin", *branches, dry_run=dry)
+    if not dry:
+        rb.disarm()
+    success(f"Branch {label} pushat{'i' if len(branches) > 1 else 'o'}")
+
+    step(f"Push tag {tag} su origin")
+    run_git("push", "origin", "--tags", dry_run=dry)
+    success(f"Tag {tag} pushato")
+
+    if release_branch:
+        step(f"Pulizia branch remoto '{release_branch}' (se presente)")
+        try:
+            run_git("push", "origin", "--delete", release_branch, dry_run=dry)
+            success(f"Branch remoto {release_branch} eliminato")
+        except RuntimeError:
+            info("Branch remoto non presente — nulla da eliminare")
+
+
 # ---------------------------------------------------------------------------
 # Flow: --from-develop
 # ---------------------------------------------------------------------------
@@ -1151,7 +1213,7 @@ def run_from_develop(version: str, plugin_ver: str | None, args: argparse.Namesp
         else:
             if not args.push:
                 print()
-                if not ask_yes_no(f"Pushare main, develop e tag {tag} su origin?"):
+                if not ask_yes_no(f"Pushare main, develop e tag {tag} su origin?", unattended=False):
                     warn("Push annullato — esegui manualmente:")
                     info("git push origin main develop && git push origin --tags")
                     print_summary(version, effective_plugin, current_pyproject, current_plugin,
@@ -1159,20 +1221,8 @@ def run_from_develop(version: str, plugin_ver: str | None, args: argparse.Namesp
                     return
                 print()
 
-            step("Push branch main e develop su origin")
-            run_git("push", "origin", "main", "develop", dry_run=dry)
-            success("Branch main e develop pushati")
-
-            step(f"Push tag {tag} su origin")
-            run_git("push", "origin", "--tags", dry_run=dry)
-            success(f"Tag {tag} pushato")
-
-            step(f"Pulizia branch remoto '{release_branch}' (se presente)")
-            try:
-                run_git("push", "origin", "--delete", release_branch, dry_run=dry)
-                success(f"Branch remoto {release_branch} eliminato")
-            except RuntimeError:
-                info("Branch remoto non presente — nulla da eliminare")
+            _push_release(rb, dry=dry, branches=("main", "develop"),
+                          tag=tag, release_branch=release_branch)
 
         # --- Post-release ---
         if not dry:
@@ -1322,7 +1372,7 @@ def run_tag_only(version: str, plugin_ver: str | None, args: argparse.Namespace)
         else:
             if not args.push:
                 print()
-                if not ask_yes_no(f"Pushare main e tag {tag} su origin?"):
+                if not ask_yes_no(f"Pushare main e tag {tag} su origin?", unattended=False):
                     warn("Push annullato — esegui manualmente:")
                     info("git push origin main && git push origin --tags")
                     print_summary(version, effective_plugin, current_pyproject, current_plugin,
@@ -1330,13 +1380,7 @@ def run_tag_only(version: str, plugin_ver: str | None, args: argparse.Namespace)
                     return
                 print()
 
-            step("Push branch main su origin")
-            run_git("push", "origin", "main", dry_run=dry)
-            success("Branch main pushato")
-
-            step(f"Push tag {tag} su origin")
-            run_git("push", "origin", "--tags", dry_run=dry)
-            success(f"Tag {tag} pushato")
+            _push_release(rb, dry=dry, branches=("main",), tag=tag, release_branch=None)
 
         # --- Post-release ---
         if not dry:
@@ -1600,6 +1644,11 @@ def parse_args() -> argparse.Namespace | None:
         action="store_true",
         help="Push without asking for confirmation",
     )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Never read stdin: every prompt takes its default (for CI/piped runs)",
+    )
 
     return parser.parse_args()
 
@@ -1614,6 +1663,9 @@ def main() -> None:
     # Interactive mode
     if args is None:
         args = interactive_setup()
+
+    if getattr(args, "non_interactive", False):
+        set_non_interactive(True)
 
     if getattr(args, "plugin_version", None) and getattr(args, "no_plugin_bump", False):
         fatal("--plugin-version and --no-plugin-bump are mutually exclusive")

--- a/tests/unit/test_release_script.py
+++ b/tests/unit/test_release_script.py
@@ -1,0 +1,224 @@
+"""Unit tests for release.py prompt/rollback safety.
+
+Regression tests for the v2.11.0 release incident (2026-07-30): with piped
+stdin, an EOF on the post-release prompt raised SystemExit(0) inside the
+RollbackContext, which rolled back LOCAL state (tag, manifests) after the
+push had already succeeded — leaving local and remote diverged.
+
+All tests are offline and side-effect free: they exercise ask()/ask_yes_no()
+with a patched input() and the RollbackContext in isolation.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "release_script", Path(__file__).parents[2] / "release.py"
+)
+rel = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(rel)
+
+
+def _raise(exc):
+    def _inner(*args, **kwargs):
+        raise exc
+    return _inner
+
+
+@pytest.fixture(autouse=True)
+def _reset_non_interactive():
+    yield
+    setter = getattr(rel, "set_non_interactive", None)
+    if setter is not None:
+        setter(False)
+
+
+# ---------------------------------------------------------------------------
+# ask() / ask_yes_no() — EOF must degrade to the default, never exit
+# ---------------------------------------------------------------------------
+
+class TestAskEof:
+    def test_ask_eof_returns_default(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", _raise(EOFError()))
+        try:
+            result = rel.ask("Domanda", "valore-default")
+        except SystemExit:
+            pytest.fail("ask() must not exit on EOF; it must return the default")
+        assert result == "valore-default"
+
+    def test_ask_eof_without_default_returns_empty(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", _raise(EOFError()))
+        try:
+            result = rel.ask("Domanda")
+        except SystemExit:
+            pytest.fail("ask() must not exit on EOF")
+        assert result == ""
+
+    def test_ask_yes_no_eof_keeps_true_default(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", _raise(EOFError()))
+        try:
+            assert rel.ask_yes_no("Procedere?", default=True) is True
+        except SystemExit:
+            pytest.fail("ask_yes_no() must not exit on EOF")
+
+    def test_ask_yes_no_eof_keeps_false_default(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", _raise(EOFError()))
+        try:
+            assert rel.ask_yes_no("Procedere?", default=False) is False
+        except SystemExit:
+            pytest.fail("ask_yes_no() must not exit on EOF")
+
+    def test_ask_yes_no_unattended_override_on_eof(self, monkeypatch):
+        # The push confirmation defaults to yes for humans, but an unattended
+        # run (EOF) must never push implicitly: unattended=False wins on EOF.
+        import inspect
+        assert "unattended" in inspect.signature(rel.ask_yes_no).parameters, (
+            "ask_yes_no() must accept unattended= for EOF/non-interactive runs"
+        )
+        monkeypatch.setattr("builtins.input", _raise(EOFError()))
+        assert rel.ask_yes_no("Pushare?", default=True, unattended=False) is False
+
+    def test_ask_yes_no_unattended_override_non_interactive(self, monkeypatch):
+        monkeypatch.setattr(
+            "builtins.input",
+            _raise(AssertionError("input() must not be called in non-interactive mode")),
+        )
+        rel.set_non_interactive(True)
+        assert rel.ask_yes_no("Pushare?", default=True, unattended=False) is False
+
+    def test_ask_yes_no_interactive_answer_beats_unattended(self, monkeypatch):
+        # unattended= only applies when stdin is unavailable; a real answer wins.
+        monkeypatch.setattr("builtins.input", lambda *a: "s")
+        assert rel.ask_yes_no("Pushare?", default=True, unattended=False) is True
+
+    def test_ask_keyboard_interrupt_still_exits(self, monkeypatch):
+        # Ctrl-C is an intentional abort: exiting is correct (with the
+        # conventional 130 code). Rollback protection for the post-push
+        # phase comes from RollbackContext.disarm(), not from swallowing
+        # the interrupt.
+        monkeypatch.setattr("builtins.input", _raise(KeyboardInterrupt()))
+        with pytest.raises(SystemExit) as excinfo:
+            rel.ask("Domanda", "default")
+        assert excinfo.value.code == 130
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive mode — prompts never touch stdin
+# ---------------------------------------------------------------------------
+
+class TestNonInteractive:
+    def test_setter_exists(self):
+        assert hasattr(rel, "set_non_interactive"), (
+            "release.py must expose set_non_interactive() for --non-interactive"
+        )
+
+    def test_ask_skips_input_entirely(self, monkeypatch):
+        monkeypatch.setattr(
+            "builtins.input",
+            _raise(AssertionError("input() must not be called in non-interactive mode")),
+        )
+        rel.set_non_interactive(True)
+        assert rel.ask("Domanda", "default") == "default"
+        assert rel.ask_yes_no("Procedere?", default=False) is False
+
+
+# ---------------------------------------------------------------------------
+# interactive_setup() — zero-args mode must refuse a non-TTY stdin
+# ---------------------------------------------------------------------------
+
+class TestInteractiveSetupGuard:
+    def test_refuses_non_tty_stdin(self, monkeypatch):
+        # With EOF degrading to defaults, a no-args run with closed stdin would
+        # otherwise walk the whole menu on defaults and return a real release
+        # Namespace. Non-TTY stdin must abort before any prompt.
+        monkeypatch.setattr(rel.sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr("builtins.input", _raise(EOFError()))
+        with pytest.raises(SystemExit) as excinfo:
+            rel.interactive_setup()
+        assert excinfo.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _push_release — the point of no return is the FIRST successful push
+# ---------------------------------------------------------------------------
+
+class TestPushRelease:
+    def test_helper_exists(self):
+        assert hasattr(rel, "_push_release"), (
+            "release.py must expose _push_release(rb, ...) so both flows share "
+            "the push sequence and its disarm point"
+        )
+
+    def test_tag_push_failure_does_not_roll_back(self, monkeypatch):
+        # Branch push succeeds, tag push fails: origin already has the release
+        # commits, so the armed rollback must NOT fire.
+        calls = []
+
+        def fake_run_git(*args, dry_run=False):
+            calls.append(args)
+            if "--tags" in args:
+                raise RuntimeError("network error")
+
+        monkeypatch.setattr(rel, "run_git", fake_run_git)
+        executed = []
+        with pytest.raises(RuntimeError, match="network error"):
+            with rel.RollbackContext(dry_run=False) as rb:
+                rb.register("canary", lambda: executed.append("rolled-back"))
+                rel._push_release(
+                    rb, dry=False, branches=("main", "develop"),
+                    tag="v9.9.9", release_branch="release/9.9.9",
+                )
+        assert calls[0] == ("push", "origin", "main", "develop")
+        assert executed == [], "rollback must not run once branches are pushed"
+
+    def test_full_push_sequence_order(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            rel, "run_git", lambda *args, dry_run=False: calls.append(args)
+        )
+        with rel.RollbackContext(dry_run=False) as rb:
+            rel._push_release(
+                rb, dry=False, branches=("main",), tag="v9.9.9", release_branch=None,
+            )
+        assert calls == [
+            ("push", "origin", "main"),
+            ("push", "origin", "--tags"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# RollbackContext — disarm() after a successful push
+# ---------------------------------------------------------------------------
+
+class TestRollbackDisarm:
+    def test_disarm_exists(self):
+        ctx = rel.RollbackContext(dry_run=False)
+        assert hasattr(ctx, "disarm"), (
+            "RollbackContext must expose disarm() to call after a successful push"
+        )
+
+    def test_disarmed_context_skips_rollback_actions(self):
+        executed = []
+        with pytest.raises(RuntimeError):
+            with rel.RollbackContext(dry_run=False) as ctx:
+                ctx.register("azione", lambda: executed.append("rolled-back"))
+                ctx.disarm()
+                raise RuntimeError("failure after push")
+        assert executed == [], "disarmed context must not run rollback actions"
+
+    def test_armed_context_still_rolls_back(self):
+        # Characterization guard: without disarm(), rollback keeps working.
+        executed = []
+        with pytest.raises(RuntimeError):
+            with rel.RollbackContext(dry_run=False) as ctx:
+                ctx.register("azione", lambda: executed.append("rolled-back"))
+                raise RuntimeError("failure before push")
+        assert executed == ["rolled-back"]
+
+    def test_disarmed_context_still_propagates_exception(self):
+        with pytest.raises(RuntimeError, match="failure after push"):
+            with rel.RollbackContext(dry_run=False) as ctx:
+                ctx.disarm()
+                raise RuntimeError("failure after push")


### PR DESCRIPTION
## Problem

During the v2.11.0 release (run with piped stdin), the post-release prompt hit EOF: `ask()` called `sys.exit(0)` **inside** the `RollbackContext`, which then rolled back LOCAL state — deleted the local tag and reverted `pyproject.toml`/`plugin.json` — while origin already had the complete release. Local and remote diverged and had to be repaired by hand.

## Fix

- `ask()`: EOF returns the default instead of exiting (Ctrl-C still aborts with exit 130)
- `RollbackContext.disarm()` — called at the point of no return, i.e. right after the **first** successful branch push, via the new shared `_push_release()` helper (used by both `--from-develop` and `--tag-only`). A later tag-push failure can no longer trigger a divergent local rollback
- Push prompts take `unattended=False`: EOF/non-interactive runs **never push implicitly** — pushing unattended requires an explicit `--push`
- New `--non-interactive` flag: every prompt takes its default, stdin is never read
- `interactive_setup()` (zero-args mode) refuses a non-TTY stdin instead of walking the whole menu on defaults

## Test plan

- 18 new unit tests in `tests/unit/test_release_script.py` (EOF/default semantics, Ctrl-C exit code, unattended override, disarm semantics, push-sequence order, tag-push-failure no-rollback, non-TTY guard) — TDD, red first
- Full suite: **2472 passed** (`-m "not live"`)
- Smoke: `release.py 9.9.9 --from-develop --dry-run < /dev/null` stops at preflight instead of dying at a prompt; `release.py < /dev/null` refuses with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)